### PR TITLE
fix: correct directionality enum mapping for graphql

### DIFF
--- a/server/app/graphql/types/directionality_type.rb
+++ b/server/app/graphql/types/directionality_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class DirectionalityType < Types::BaseEnum
+    value :activating
+    value :inhibitory
+  end
+end

--- a/server/app/graphql/types/directionality_type.rb
+++ b/server/app/graphql/types/directionality_type.rb
@@ -1,7 +1,7 @@
 module Types
   class DirectionalityType < Types::BaseEnum
-    value :activating
-    value :inhibitory
-    value :directionality_unclear
+    value :ACTIVATING, value: 'activating'
+    value :INHIBITORY, value: 'inhibitory'
+    value :DIRECTIONALITY_UNCLEAR, value: 'directionality unclear'
   end
 end

--- a/server/app/graphql/types/directionality_type.rb
+++ b/server/app/graphql/types/directionality_type.rb
@@ -2,5 +2,6 @@ module Types
   class DirectionalityType < Types::BaseEnum
     value :activating
     value :inhibitory
+    value :directionality_unclear
   end
 end

--- a/server/app/graphql/types/interaction_claim_type_type.rb
+++ b/server/app/graphql/types/interaction_claim_type_type.rb
@@ -2,7 +2,7 @@ module Types
   class InteractionClaimTypeType < Types::BaseObject
     field :id, ID, null: false
     field :type, String, null: true
-    field :directionality, Int, null: true
+    field :directionality, Types::DirectionalityType, null: true
     field :definition, String, null: true
     field :reference, String, null: true
     field :interaction_claims, [Types::InteractionClaimType], null: false


### PR DESCRIPTION
close #97 

I think this is the correct way to do this (@acoffman)?

Also, it looks to me like "directionality unclear" isn't used by any importers, maybe delete?