### PR TITLE
Precompute Interaction Scores

### DIFF
--- a/server/app/models/interaction.rb
+++ b/server/app/models/interaction.rb
@@ -42,6 +42,16 @@ class Interaction < ActiveRecord::Base
   end
 
   def interaction_score(known_drug_partners_per_gene = nil, known_gene_partners_per_drug = nil)
+    if known_drug_partners_per_gene.present? || known_gene_partners_per_drug.present?
+      calculate_interaction_score(known_drug_partners_per_gene, known_gene_partners_per_drug)
+    elsif self.score.nil?
+      calculate_interaction_score(known_drug_partners_per_gene, known_gene_partners_per_drug)
+    else
+      self.score
+    end
+  end
+
+  def calculate_interaction_score(known_drug_partners_per_gene = nil, known_gene_partners_per_drug = nil)
     known_drug_partners_per_gene = Interaction.group(:gene_id).count if known_drug_partners_per_gene.nil?
     average_known_drug_partners_per_gene = known_drug_partners_per_gene.values.sum / known_drug_partners_per_gene.values.size.to_f
     known_gene_partners_per_drug = Interaction.group(:drug_id).count if known_gene_partners_per_drug.nil?
@@ -51,4 +61,5 @@ class Interaction < ActiveRecord::Base
 
     (self.publications.count + self.sources.count) * average_known_gene_partners_per_drug/known_gene_partners_for_interaction_drug * average_known_drug_partners_per_gene/known_drug_partners_for_interaction_gene
   end
+
 end

--- a/server/db/migrate/20220511151940_add_interaction_score_to_interactions.rb
+++ b/server/db/migrate/20220511151940_add_interaction_score_to_interactions.rb
@@ -1,0 +1,5 @@
+class AddInteractionScoreToInteractions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :interactions, :score, :decimal, index: true
+  end
+end

--- a/server/lib/genome/groupers/interaction_grouper.rb
+++ b/server/lib/genome/groupers/interaction_grouper.rb
@@ -13,6 +13,7 @@ module Genome
           puts 'Adding interaction groups...'
           add_members(group_from_scratch)
         end
+        cache_interaction_scores
         Utils::Database.destroy_empty_groups
         Utils::Database.destroy_unsourced_attributes
         Utils::Database.destroy_unsourced_aliases
@@ -85,6 +86,13 @@ module Genome
 
         interaction_claim.save
         interaction.save
+      end
+
+      def self.cache_interaction_scores
+        Interaction.find_each do |interaction|
+          interaction.score = interaction.calculate_interaction_score
+          interaction.save!
+        end
       end
     end
   end


### PR DESCRIPTION
In the common case (no partners are passed in) we can calculate the interaction score at grouping time (or on demand) and return it directly rather than on the fly.