### PR TITLE
Drop primary name from drug claim

### DIFF
--- a/server/app/graphql/types/drug_claim_type.rb
+++ b/server/app/graphql/types/drug_claim_type.rb
@@ -4,7 +4,6 @@ module Types
     field :name, String, null: false
     field :nomenclature, String, null: false
     field :source_id, ID, null: true
-    field :primary_name, String, null: true
     field :drug_id, ID, null: true
     field :drug, Types::DrugType, null: true
     field :drug_claim_aliases, [Types::DrugClaimAliasType], null: false

--- a/server/app/models/drug_claim.rb
+++ b/server/app/models/drug_claim.rb
@@ -41,7 +41,7 @@ class DrugClaim < ::ActiveRecord::Base
   end
 
   def names
-    @names ||= (self.drug_claim_aliases.pluck(:alias) + [self.name, self.primary_name]).compact.map(&:upcase).to_set
+    @names ||= (self.drug_claim_aliases.pluck(:alias) + [self.name]).compact.map(&:upcase).to_set
   end
 
   def cleaned_names

--- a/server/db/migrate/20220520001558_update_drug_claims.rb
+++ b/server/db/migrate/20220520001558_update_drug_claims.rb
@@ -1,0 +1,9 @@
+class UpdateDrugClaims < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :drug_claims, :primary_name
+  end
+
+  def down
+    add_column :drug_claims, :primary_name, :string, limit: 255
+  end
+end

--- a/server/lib/genome/groupers/base.rb
+++ b/server/lib/genome/groupers/base.rb
@@ -30,31 +30,23 @@ module Genome
         body['source_matches'].reduce({}) { |map, source| map.update(source['source'] => source['source_meta_']) }
       end
 
-      # Normalize claim terms. `secondary_term` can be nil.
-      def normalize_claim(primary_term, secondary_term, claim_aliases)
+      # Normalize claim terms.
+      def normalize_claim(primary_term, claim_aliases)
         primary_term_upcase = primary_term.upcase
         return @term_to_match_dict[primary_term_upcase] if key_non_nil_match(primary_term_upcase)
 
         response = retrieve_normalizer_response(primary_term)
         if response.nil? || response['match_type'].zero?
-          unless secondary_term.nil? || primary_term == secondary_term
-            secondary_term_upcase = secondary_term.upcase
-            return @term_to_match_dict[secondary_term_upcase] if key_non_nil_match(secondary_term_upcase)
-
-            response = retrieve_normalizer_response(secondary_term)
-          end
-          if response.nil? || response['match_type'].zero?
-            best_match = nil
-            best_match_type = 0
-            claim_aliases.each do |claim_alias|
-              response = retrieve_normalizer_response(claim_alias.alias)
-              if !response.nil? && response['match_type'] > best_match_type
-                best_match = response
-                best_match_type = response['match_type']
-              end
+          best_match = nil
+          best_match_type = 0
+          claim_aliases.each do |claim_alias|
+            response = retrieve_normalizer_response(claim_alias.alias)
+            if !response.nil? && response['match_type'] > best_match_type
+              best_match = response
+              best_match_type = response['match_type']
             end
-            response = best_match
           end
+          response = best_match
         end
         response
       end

--- a/server/lib/genome/groupers/gene_grouper.rb
+++ b/server/lib/genome/groupers/gene_grouper.rb
@@ -36,7 +36,7 @@ module Genome
         create_sources
 
         claims.each do |gene_claim|
-          normalized_gene = normalize_claim(gene_claim.name, nil, gene_claim.gene_claim_aliases)
+          normalized_gene = normalize_claim(gene_claim.name, gene_claim.gene_claim_aliases)
           next if normalized_gene.nil?
 
           if normalized_gene.is_a? String

--- a/server/lib/genome/importers/api_importers/civic/importer.rb
+++ b/server/lib/genome/importers/api_importers/civic/importer.rb
@@ -47,7 +47,7 @@ module Genome
               if ei['evidence_level'] == 'A'
                 create_gene_claim_category(gc, 'CLINICALLY ACTIONABLE')
               end
-              dc = create_drug_claim(drug['name'].upcase, drug['name'].upcase, 'CIViC Drug Name')
+              dc = create_drug_claim(drug['name'].upcase, 'CIViC Drug Name')
               ic = create_interaction_claim(gc, dc)
               if ei['source']['citation_id'].present? and ei['source']['source_type'] == 'PubMed'
                 create_interaction_claim_publication(ic, ei['source']['citation_id'])

--- a/server/lib/genome/importers/api_importers/docm/importer.rb
+++ b/server/lib/genome/importers/api_importers/docm/importer.rb
@@ -20,7 +20,6 @@ module Genome; module Importers; module ApiImporters; module Docm
         interaction_information.each do |interaction_info|
           gc = create_gene_claim(variant['gene'], 'DoCM Entrez Gene Symbol')
           dc = create_drug_claim(interaction_info['Therapeutic Context'].upcase,
-                                 interaction_info['Therapeutic Context'].upcase,
                                  'DoCM Drug Name')
           ic = create_interaction_claim(gc, dc)
           create_interaction_claim_attributes(ic, interaction_info)

--- a/server/lib/genome/importers/api_importers/jax_ckb/importer.rb
+++ b/server/lib/genome/importers/api_importers/jax_ckb/importer.rb
@@ -38,7 +38,7 @@ module Genome; module Importers; module ApiImporters; module JaxCkb;
           if drug_name.include? '+'
             combination_drug_name = drug_name
             combination_drug_name.split(' + ').each do |individual_drug_name|
-              drug_claim = create_drug_claim(individual_drug_name, individual_drug_name, 'CKB Drug Name')
+              drug_claim = create_drug_claim(individual_drug_name, 'CKB Drug Name')
               interaction_claim = create_interaction_claim(gene_claim, drug_claim)
               create_interaction_claim_attribute(interaction_claim, 'combination therapy', combination_drug_name)
               create_interaction_claim_publications(interaction_claim, interaction['References'])
@@ -46,7 +46,7 @@ module Genome; module Importers; module ApiImporters; module JaxCkb;
               create_interaction_claim_link(interaction_claim, "#{gene['geneName']} Gene Level Evidence", "https://ckb.jax.org/gene/show?geneId=#{gene['id']}&tabType=GENE_LEVEL_EVIDENCE")
             end
           else
-            drug_claim = create_drug_claim(drug_name, drug_name, 'CKB Drug Name')
+            drug_claim = create_drug_claim(drug_name, 'CKB Drug Name')
             interaction_claim = create_interaction_claim(gene_claim, drug_claim)
             create_interaction_claim_publications(interaction_claim, interaction['References'])
             create_interaction_claim_attributes(interaction_claim, interaction)

--- a/server/lib/genome/importers/base.rb
+++ b/server/lib/genome/importers/base.rb
@@ -103,10 +103,9 @@ module Genome
         end
       end
 
-      def create_drug_claim(name, primary_name, nomenclature, source=@source)
+      def create_drug_claim(name, nomenclature, source=@source)
         DrugClaim.where(
           name: name.strip,
-          primary_name: primary_name.strip,
           nomenclature: nomenclature.strip,
           source_id: source.id
         ).first_or_create

--- a/server/lib/genome/importers/file_importers/cancer_commons.rb
+++ b/server/lib/genome/importers/file_importers/cancer_commons.rb
@@ -37,8 +37,7 @@ module Genome; module Importers; module FileImporters; module CancerCommons;
         create_gene_claim_alias(gene_claim, row['entrez_gene_id'], 'Entrez Gene ID')
         create_gene_claim_attribute(gene_claim, 'CancerCommons Reported Gene Name', row['reported_gene_name'])
 
-        primary_name = row['primary_drug_name'].strip.upcase
-        drug_claim = create_drug_claim(primary_name, primary_name, 'Primary Drug Name')
+        drug_claim = create_drug_claim(row['primary_drug_name'].strip.upcase, 'Primary Drug Name')
         create_drug_claim_attribute(drug_claim, 'Drug Class', row['drug_class'])
         create_drug_claim_attribute(drug_claim, 'Source Reported Drug Name(s)', row['source_reported_drug_name'])
         create_drug_claim_attribute(drug_claim, 'Pharmaceutical Developer', row['pharmaceutical_developer'])

--- a/server/lib/genome/importers/file_importers/cgi.rb
+++ b/server/lib/genome/importers/file_importers/cgi.rb
@@ -44,7 +44,7 @@ module Genome; module Importers; module FileImporters; module Cgi
           combination_drug_name = row['Drug']
           combination_drug_name.scan(/[a-zA-Z0-9]+/).each do |individual_drug_name|
             individual_drug_name = clean_drug_name(individual_drug_name)
-            drug_claim = create_drug_claim(individual_drug_name, individual_drug_name, 'CGI Drug Name')
+            drug_claim = create_drug_claim(individual_drug_name, 'CGI Drug Name')
             if row['Gene'].include?(';')
               row['Gene'].split(';').each do |indv_gene|
                 gene_claim = create_gene_claim(indv_gene, 'CGI Gene Name')
@@ -71,7 +71,7 @@ module Genome; module Importers; module FileImporters; module Cgi
             combination_drug_name = row['Drug']
             combination_drug_name.split(';').each do |individual_drug_name|
               individual_drug_name = clean_drug_name(individual_drug_name)
-              drug_claim = create_drug_claim(individual_drug_name, individual_drug_name, 'CGI Drug Name')
+              drug_claim = create_drug_claim(individual_drug_name, 'CGI Drug Name')
               if row['Gene'].include?(';')
                 row['Gene'].split(';').each do |indv_gene|
                   gene_claim = create_gene_claim(indv_gene, 'CGI Gene Name')
@@ -95,7 +95,7 @@ module Genome; module Importers; module FileImporters; module Cgi
           end
         else
           drug_name = clean_drug_name(row['Drug'])
-          drug_claim = create_drug_claim(drug_name, drug_name, 'CGI Drug Name')
+          drug_claim = create_drug_claim(drug_name, 'CGI Drug Name')
           if row['Gene'].include?(';')
             row['Gene'].split(';').each do |indv_gene|
               gene_claim = create_gene_claim(indv_gene, 'CGI Gene Name')

--- a/server/lib/genome/importers/file_importers/chembl.rb
+++ b/server/lib/genome/importers/file_importers/chembl.rb
@@ -68,7 +68,7 @@ module Genome; module Importers; module FileImporters; module Chembl
     def create_interaction_claims
       @chembl_data.each do |row|
         primary_drug_name = row[2].strip.upcase
-        drug_claim = create_drug_claim(primary_drug_name, primary_drug_name, "Primary Drug Name")
+        drug_claim = create_drug_claim(primary_drug_name, "Primary Drug Name")
         create_drug_claim_alias(drug_claim, row[1], "ChEMBL ID")
         create_drug_claim_attribute(drug_claim, "Approval Rating", "chembl_phase_#{row[5]}") unless row[5].nil?
         create_drug_claim_attribute(drug_claim, 'Approval Rating', 'chembl_withdrawn') unless row[3] != 1

--- a/server/lib/genome/importers/file_importers/clearity_foundation_biomarkers.rb
+++ b/server/lib/genome/importers/file_importers/clearity_foundation_biomarkers.rb
@@ -37,7 +37,7 @@ module Genome; module Importers; module FileImporters; module ClearityFoundation
         create_gene_claim_alias(gene_claim, row['entrez_gene_id'], 'Entrez Gene ID')
         create_gene_claim_attribute(gene_claim, 'Reported Genome Event Targeted', row['reported_gene_name'])
 
-        drug_claim = create_drug_claim(row['drug_name'].upcase, row['drug_name'].upcase, 'Primary Drug Name')
+        drug_claim = create_drug_claim(row['drug_name'].upcase, 'Primary Drug Name')
         create_drug_claim_attribute(drug_claim, 'Drug Class', row['drug_class'])
         unless row['drug_trade_name'].blank?
           create_drug_claim_alias(drug_claim, row['drug_trade_name'], 'Drug Trade Name')

--- a/server/lib/genome/importers/file_importers/clearity_foundation_clinical_trial.rb
+++ b/server/lib/genome/importers/file_importers/clearity_foundation_clinical_trial.rb
@@ -37,7 +37,7 @@ module Genome; module Importers; module FileImporters; module ClearityFoundation
         create_gene_claim_alias(gene_claim, row['Enterez Gene Id'], 'Entrez Gene ID')
         create_gene_claim_attribute(gene_claim, 'Reported Genome Event Targeted', row['Molecular Target'])
 
-        drug_claim = create_drug_claim(row['Pubchem name'].upcase, row['Pubchem name'].upcase, 'Primary Drug Name')
+        drug_claim = create_drug_claim(row['Pubchem name'].upcase, 'Primary Drug Name')
         create_drug_claim_alias(drug_claim, row['Drug name'], 'Drug Trade Name')
         create_drug_claim_alias(drug_claim, row['CID'], 'PubChem Drug ID') unless row['CID'] == 'N/A'
         create_drug_claim_alias(drug_claim, row['SID'], 'PubChem Drug SID') unless row['SID'] == 'N/A'

--- a/server/lib/genome/importers/file_importers/cosmic.rb
+++ b/server/lib/genome/importers/file_importers/cosmic.rb
@@ -37,7 +37,7 @@ module Genome; module Importers; module FileImporters; module Cosmic
 
     def create_interaction_claims
       CSV.foreach(file_path, headers: true, col_sep: ',') do |row|
-        drug_claim = create_drug_claim(row['Drug'], row['Drug'], 'COSMIC Drug Name')
+        drug_claim = create_drug_claim(row['Drug'], 'COSMIC Drug Name')
 
         row['Genes'].split(', ').each do |gene|
           next if gene.blank?

--- a/server/lib/genome/importers/file_importers/drugbank.rb
+++ b/server/lib/genome/importers/file_importers/drugbank.rb
@@ -50,7 +50,7 @@ module Genome; module Importers; module FileImporters; module Drugbank;
                   create_gene_claim_alias(gene_claim, syn, nomen)
                 end
 
-                drug_claim = create_drug_claim(record[1], record[1], 'DrugBank Drug Name')
+                drug_claim = create_drug_claim(record[1], 'DrugBank Drug Name')
 
                 create_drug_claim_alias(drug_claim, record[0], 'DrugBank Identifier')
 

--- a/server/lib/genome/importers/file_importers/dtc.rb
+++ b/server/lib/genome/importers/file_importers/dtc.rb
@@ -42,7 +42,7 @@ module Genome; module Importers; module FileImporters; module Dtc;
         pmid = row['pubmed_id']
         mechanism = row['ep_action_mode']
         unless drug_name.nil? || gene_name.nil?
-          drug_claim = create_drug_claim(drug_name, drug_name, 'DTC Drug Name')
+          drug_claim = create_drug_claim(drug_name, 'DTC Drug Name')
           unless drug_id.nil?
             create_drug_claim_alias(drug_claim, drug_id, 'ChEMBL Drug ID')
           end

--- a/server/lib/genome/importers/file_importers/fda.rb
+++ b/server/lib/genome/importers/file_importers/fda.rb
@@ -34,7 +34,7 @@ module Genome; module Importers; module FileImporters; module Fda
       if row['Drug'].include?(',')
         combination_therapy = row['Drug']
         row['Drug'].split(',').each do |drug|
-          drug_claim = create_drug_claim(drug, drug, 'FDA Drug Name')
+          drug_claim = create_drug_claim(drug, 'FDA Drug Name')
           interaction_claim = create_interaction_claim(gene_claim, drug_claim)
           create_interaction_claim_attribute(interaction_claim, 'Combination therapy', combination_therapy)
           if !fusion_protein.nil?
@@ -43,7 +43,7 @@ module Genome; module Importers; module FileImporters; module Fda
           create_interaction_claim_link(interaction_claim, 'Table of Pharmacogenomic Biomarkers in Drug Labeling', 'https://www.fda.gov/drugs/science-and-research-drugs/table-pharmacogenomic-biomarkers-drug-labeling')
         end
       else
-        drug_claim = create_drug_claim(row['Drug'], row['Drug'], 'FDA Drug Name')
+        drug_claim = create_drug_claim(row['Drug'], 'FDA Drug Name')
         interaction_claim = create_interaction_claim(gene_claim, drug_claim)
         if not fusion_protein.nil?
           create_interaction_claim_attribute(interaction_claim, 'Fusion protein', fusion_protein)

--- a/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
+++ b/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
@@ -85,7 +85,7 @@ module Genome; module Importers; module FileImporters; module GuideToPharmacolog
         gene_claim = create_gene_claim(target_to_entrez[line['target_id']], 'Entrez Gene ID')
         create_gene_claim_aliases(gene_claim, line)
 
-        drug_claim = create_drug_claim(line['ligand_pubchem_sid'], strip_tags(line['ligand']).upcase, 'PubChem Drug SID')
+        drug_claim = create_drug_claim("pubchem.substance:#{line['ligand_pubchem_sid']}", 'Concept ID')
         create_drug_claim_aliases(drug_claim, line)
         unless blank?(line['ligand_species'])
           create_drug_claim_attribute(drug_claim, 'Name of the Ligand Species (if a Peptide)', line['ligand_species'])
@@ -129,12 +129,12 @@ module Genome; module Importers; module FileImporters; module GuideToPharmacolog
     end
 
     def create_drug_claim_aliases(drug_claim, line)
-      unless blank?(line['ligand_gene_symbol'])
-        line['ligand_gene_symbol'].split('|').each do |gene_symbol|
-          create_drug_claim_alias(drug_claim, gene_symbol, 'Gene Symbol (for Endogenous Peptides)')
-        end
-      end
       create_drug_claim_alias(drug_claim, strip_tags(line['ligand']).upcase, 'GuideToPharmacology Ligand Name')
+      return if blank?(line['ligand_gene_symbol'])
+
+      line['ligand_gene_symbol'].split('|').each do |gene_symbol|
+        create_drug_claim_alias(drug_claim, gene_symbol, 'Gene Symbol (for Endogenous Peptides)')
+      end
     end
 
     def blank?(value)

--- a/server/lib/genome/importers/file_importers/my_cancer_genome_clinical_trial.rb
+++ b/server/lib/genome/importers/file_importers/my_cancer_genome_clinical_trial.rb
@@ -38,7 +38,7 @@ module Genome; module Importers; module FileImporters; module MyCancerGenomeClin
         create_gene_claim_alias(gene_claim, row['Gene ID'], 'Entrez Gene ID') unless row['Gene ID'] == 'N/A'
         create_gene_claim_attribute(gene_claim, 'Reported Genome Event Targeted', row['genes']) unless row['genes'] == 'N/A'
 
-        drug_claim = create_drug_claim(row['pubchem drug name'].upcase, row['pubchem drug name'].upcase, 'Primary Drug Name')
+        drug_claim = create_drug_claim(row['pubchem drug name'].upcase, 'Primary Drug Name')
         create_drug_claim_alias(drug_claim, row['Drug name'], 'Drug Trade Name') unless row['Drug name'] == 'N/A'
         create_drug_claim_alias(drug_claim, row['pubchem drug id'], 'PubChem Drug ID') unless row['pubchem drug id'] == 'N/A'
         create_drug_claim_alias(drug_claim, row['Other drug names'], 'Other Drug Name') unless row['Other drug names'] == 'N/A'

--- a/server/lib/genome/importers/file_importers/nci.rb
+++ b/server/lib/genome/importers/file_importers/nci.rb
@@ -31,7 +31,7 @@ module Genome; module Importers; module FileImporters; module Nci;
       CSV.foreach(file_path, encoding:'iso-8859-1:utf-8', :headers => true, :col_sep => "\t") do |row|
         gene_claim = create_gene_claim(row['Gene'], 'CGI Gene Name')
         drug = row['Drug'].upcase
-        drug_claim = create_drug_claim(drug, drug, 'NCI Drug Name')
+        drug_claim = create_drug_claim(drug, 'NCI Drug Name')
         create_drug_claim_alias(drug_claim, row['NCI drug code'], 'NCI drug code')
         interaction_claim = create_interaction_claim(gene_claim, drug_claim)
         create_interaction_claim_publication(interaction_claim, row['PMID'])

--- a/server/lib/genome/importers/file_importers/pharmgkb.rb
+++ b/server/lib/genome/importers/file_importers/pharmgkb.rb
@@ -39,7 +39,7 @@ module Genome; module Importers; module FileImporters; module Pharmgkb;
           pharmgkb_gene_id = row['Entity1_id']
           drug_name = row['Entity2_name']
           pharmgkb_drug_id = row['Entity2_id']
-          drug_claim = create_drug_claim(drug_name, drug_name, 'PharmGKB Drug Name')
+          drug_claim = create_drug_claim(drug_name, 'PharmGKB Drug Name')
           create_drug_claim_alias(drug_claim, pharmgkb_drug_id, 'PharmGKB ID')
           gene_claim = create_gene_claim(gene_name, 'PharmGKB Gene Name')
           create_gene_claim_alias(gene_claim, pharmgkb_gene_id, 'PharmGKB ID')
@@ -53,7 +53,7 @@ module Genome; module Importers; module FileImporters; module Pharmgkb;
           pharmgkb_drug_id = row['Entity1_id']
           gene_name = row['Entity2_name']
           pharmgkb_gene_id = row['Entity2_id']
-          drug_claim = create_drug_claim(drug_name, drug_name, 'PharmGKB Drug Name')
+          drug_claim = create_drug_claim(drug_name, 'PharmGKB Drug Name')
           create_drug_claim_alias(drug_claim, pharmgkb_drug_id, 'PharmGKB ID')
           gene_claim = create_gene_claim(gene_name, 'PharmGKB Gene Name')
           create_gene_claim_alias(gene_claim, pharmgkb_gene_id, 'PharmGKB ID')

--- a/server/lib/genome/importers/file_importers/talc.rb
+++ b/server/lib/genome/importers/file_importers/talc.rb
@@ -36,7 +36,7 @@ module Genome; module Importers; module FileImporters; module Talc;
         create_gene_claim_alias(gene_claim, row['gene_target'], 'Gene Symbol')
         create_gene_claim_alias(gene_claim, row['entrez_id'], 'Entrez ID')
 
-        drug_claim = create_drug_claim(row['drug_name'].upcase, row['drug_name'].upcase, 'TALC')
+        drug_claim = create_drug_claim(row['drug_name'].upcase, 'TALC')
         create_drug_claim_alias(drug_claim, row['drug_name'], 'Primary Drug Name')
         unless row['drug_generic_name'] == 'NA'
           create_drug_claim_alias(drug_claim, row['drug_generic_name'], 'Drug Generic Name')

--- a/server/lib/genome/importers/file_importers/tdg_clinical_trial.rb
+++ b/server/lib/genome/importers/file_importers/tdg_clinical_trial.rb
@@ -44,7 +44,7 @@ module Genome; module Importers; module FileImporters; module TdgClinicalTrial;
           end
         end
 
-        drug_claim = create_drug_claim(row['Drug Name'].upcase, row['Drug Name'].upcase, 'Drug Name')
+        drug_claim = create_drug_claim(row['Drug Name'].upcase, 'Drug Name')
         row['Indication(s)'].gsub('"', '').split(',').each do |indication|
           create_drug_claim_attribute(drug_claim, 'Drug Indications', indication)
         end

--- a/server/lib/genome/importers/file_importers/tend.rb
+++ b/server/lib/genome/importers/file_importers/tend.rb
@@ -42,7 +42,7 @@ module Genome; module Importers; module FileImporters; module Tend;
         end
         create_gene_claim_attribute(gene_claim, 'Transmembrane Helix Count', row['Number of transmembrane helices'])
 
-        drug_claim = create_drug_claim(row['Drug name'], row['Drug name'], 'TEND')
+        drug_claim = create_drug_claim(row['Drug name'], 'TEND')
         create_drug_claim_alias(drug_claim, row['Drug name'], 'Primary Drug Name')
         row['Indication(s)'].split('; ').each do |indication|
           create_drug_claim_attribute(drug_claim, 'Drug Class', indication)

--- a/server/lib/genome/importers/file_importers/ttd.rb
+++ b/server/lib/genome/importers/file_importers/ttd.rb
@@ -47,7 +47,7 @@ module Genome; module Importers; module FileImporters; module Ttd;
         create_gene_claim_alias(gene_claim, gene_abbreviation, 'TTD Gene Abbreviation')
         create_gene_claim_alias(gene_claim, row['TargetID'], 'TTD Target ID')
 
-        drug_claim = create_drug_claim(row['Drug_Name'], row['Drug_Name'], 'TTD Drug Name')
+        drug_claim = create_drug_claim(row['Drug_Name'], 'TTD Drug Name')
         create_drug_claim_alias(drug_claim, row['DrugID'], 'TTD Drug ID')
 
         interaction_claim = create_interaction_claim(gene_claim, drug_claim)

--- a/server/lib/genome/online_updater.rb
+++ b/server/lib/genome/online_updater.rb
@@ -32,10 +32,9 @@ module Genome
       gene_claim.gene_claim_categories << gene_category unless gene_claim.gene_claim_categories.include? gene_category
     end
 
-    def create_drug_claim(name, primary_name, nomenclature, source=@source)
+    def create_drug_claim(name, nomenclature, source=@source)
       DrugClaim.where(
         name: name.strip,
-        primary_name: primary_name.strip,
         nomenclature: nomenclature.strip,
         source_id: source.id
       ).first_or_create

--- a/server/lib/utils/database.rb
+++ b/server/lib/utils/database.rb
@@ -391,10 +391,9 @@ module Utils
         a.value = a.value.strip
         a.save!
       end
-      DrugClaim.where("name LIKE ' %' or name LIKE '% ' or primary_name LIKE ' %' or primary_name LIKE '% '").all.each do |c|
+      DrugClaim.where("name LIKE ' %' or name LIKE '% '").all.each do |c|
         clean_name = c.name.strip
-        clean_primary_name = c.primary_name.strip
-        clean_claim = DrugClaim.where(name: clean_name, primary_name: clean_primary_name, nomenclature: c.nomenclature, source_id: c.source_id).first_or_create
+        clean_claim = DrugClaim.where(name: clean_name, nomenclature: c.nomenclature, source_id: c.source_id).first_or_create
         c.drug_claim_aliases.each do |synonym|
           DrugClaimAlias.where(alias: synonym.alias, nomenclature: synonym.nomenclature, drug_claim_id: clean_claim.id).first_or_create
           synonym.delete


### PR DESCRIPTION
`primary_name` is equal to `name` for all drug claims other than normalizer-provided sources, and GuideToPharmacology. This seems unnecessary. 