### PR TITLE
feat: add oncokb "importer"

### DIFF
--- a/server/lib/genome/importers/file_importers/oncokb.rb
+++ b/server/lib/genome/importers/file_importers/oncokb.rb
@@ -1,0 +1,79 @@
+module Genome; module Importers; module FileImporters; module Oncokb;
+  class Importer < Genome::Importers::Base
+    def initialize(tsv_root_path)
+      if tsv_root_path.nil?
+        @tsv_root = 'lib/data/oncokb/'
+      else
+        @tsv_root = tsv_root_path
+      end
+      @source_db_name = 'OncoKB'
+      @drug_claims = {}
+      @gene_claims = {}
+      @interaction_claims = {}
+    end
+
+    def create_claims
+      create_drug_claims
+      create_gene_claims
+      create_interaction_claims
+    end
+
+    private
+
+    def create_new_source
+      @source ||= Source.create(
+        base_url: 'https://www.oncokb.org',
+        citation: 'OncoKB: A Precision Oncology Knowledge Base. Chakravarty D, Gao J, Phillips S, et. al. JCO Precision Oncology 2017 :1, 1-16. PMID: 28890946',
+        site_url: 'http://www.oncokb.org/',
+        source_db_name: source_db_name,
+        source_db_version: '23-July-2020',
+        source_trust_level_id: SourceTrustLevel.NON_CURATED,
+        full_name: 'OncoKB: A Precision Oncology Knowledge Base',
+        license: 'Restrictive, non-commercial',
+        license_link: 'https://www.oncokb.org/terms'
+      )
+      @source.source_types << SourceType.find_by(type: 'interaction')
+      @source.save
+    end
+
+    def create_drug_claims
+      CSV.foreach("#{@tsv_root}drug_claim.csv", headers: false, col_sep: ',') do |row|
+        dc = create_drug_claim(row[0], row[1])
+        @drug_claims[row[0]] = dc
+      end
+    end
+
+    def create_gene_claims
+      CSV.foreach("#{@tsv_root}gene_claim.csv", headers: false, col_sep: ',') do |row|
+        gc = create_gene_claim(row[0], row[1])
+        @gene_claims[row[0]] = gc
+      end
+      CSV.foreach("#{@tsv_root}gene_claim_aliases.csv", headers: false, col_sep: ',') do |row|
+        gc = @gene_claims[row[0]]
+        create_gene_claim_alias(gc, row[1], row[2])
+      end
+    end
+
+    def create_interaction_claims
+      CSV.foreach("#{@tsv_root}interaction_claim.csv", headers: false, col_sep: ',') do |row|
+        gc = @gene_claims[row[1]]
+        dc = @drug_claims[row[0]]
+        ic = create_interaction_claim(gc, dc)
+        @interaction_claims[[gc, dc]] = ic
+
+      end
+      CSV.foreach("#{@tsv_root}interaction_claim_attributes.csv", headers: false, col_sep: ',') do |row|
+        gc = @gene_claims[row[3]]
+        dc = @drug_claims[row[2]]
+        ic = @interaction_claims[[gc, dc]]
+        create_interaction_claim_attribute(ic, row[0], row[1])
+      end
+      CSV.foreach("#{@tsv_root}interaction_claim_links.csv", headers: false, col_sep: ',') do |row|
+        gc = @gene_claims[row[3]]
+        dc = @drug_claims[row[2]]
+        ic = @interaction_claims[[gc, dc]]
+        create_interaction_claim_link(ic, row[0], row[1])
+      end
+    end
+  end
+end; end; end; end;

--- a/server/lib/genome/importers/file_importers/oncokb.sql
+++ b/server/lib/genome/importers/file_importers/oncokb.sql
@@ -46,5 +46,3 @@ FROM interaction_claims ic
          LEFT JOIN gene_claims gc on ic.gene_claim_id = gc.id
          RIGHT JOIN interaction_claim_links icl on ic.id = icl.interaction_claim_id
 WHERE s.source_db_name = 'OncoKB';
-
-

--- a/server/lib/genome/importers/file_importers/oncokb.sql
+++ b/server/lib/genome/importers/file_importers/oncokb.sql
@@ -1,0 +1,50 @@
+-- We aren't currently able to get everything we need from the OncoKB API endpoint;
+-- These queries make it easier to transfer data from the DGIdb v4 database by
+-- producing outputs that, when exported as CSVs, can be ingested by a file importer.
+
+-- gene claim
+SELECT gc.name, gc.nomenclature
+FROM gene_claims gc
+         LEFT JOIN sources s on gc.source_id = s.id
+WHERE source_db_name = 'OncoKB';
+
+-- gene claim aliases
+SELECT name, alias, gca.nomenclature
+FROM gene_claim_aliases gca
+         LEFT JOIN gene_claims gc on gca.gene_claim_id = gc.id
+         LEFT JOIN sources s on gc.source_id = s.id
+WHERE s.source_db_name = 'OncoKB';
+
+-- drug claim
+SELECT dc.name, dc.nomenclature
+FROM drug_claims dc
+         LEFT JOIN sources s on dc.source_id = s.id
+WHERE s.source_db_name = 'OncoKB';
+
+-- interaction claim
+SELECT dc.name, gc.name
+FROM interaction_claims ic
+         LEFT JOIN sources s on ic.source_id = s.id
+         LEFT JOIN drug_claims dc on ic.drug_claim_id = dc.id
+         LEFT JOIN gene_claims gc on ic.gene_claim_id = gc.id
+WHERE s.source_db_name = 'OncoKB';
+
+-- interaction claim attributes
+SELECT ica.name, ica.value, dc.name, gc.name
+FROM interaction_claims ic
+         LEFT JOIN sources s on ic.source_id = s.id
+         LEFT JOIN drug_claims dc on ic.drug_claim_id = dc.id
+         LEFT JOIN gene_claims gc on ic.gene_claim_id = gc.id
+         RIGHT JOIN interaction_claim_attributes ica on ic.id = ica.interaction_claim_id
+WHERE s.source_db_name = 'OncoKB';
+
+-- interaction claim links
+SELECT icl.link_text, icl.link_url, dc.name, gc.name
+FROM interaction_claims ic
+         LEFT JOIN sources s on ic.source_id = s.id
+         LEFT JOIN drug_claims dc on ic.drug_claim_id = dc.id
+         LEFT JOIN gene_claims gc on ic.gene_claim_id = gc.id
+         RIGHT JOIN interaction_claim_links icl on ic.id = icl.interaction_claim_id
+WHERE s.source_db_name = 'OncoKB';
+
+


### PR DESCRIPTION
As far as I can tell, OncoKB no longer provides an endpoint that lists every curated variant and drug annotation. Until that changes, or we figure out what I'm missing, I've manually dumped the OncoKB data from the v4 database into some CSVs (see provided SQL queries file) and written up a quick importer to pull them in.

Close #47 