### PR TITLE
ci: use latest checkout version

### DIFF
--- a/.github/workflows/deploy_client.yaml
+++ b/.github/workflows/deploy_client.yaml
@@ -36,7 +36,7 @@ jobs:
       run:
         working-directory: ./client
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/test_client_build.yaml
+++ b/.github/workflows/test_client_build.yaml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: ./client
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install dependencies
         run: yarn install
       - name: build


### PR DESCRIPTION
Upgrade actions/checkout to v3 to silence warning about deprecated node version