### PR TITLE
Expose additional fields

### DIFF
--- a/server/app/graphql/types/drug_application_type.rb
+++ b/server/app/graphql/types/drug_application_type.rb
@@ -3,6 +3,7 @@ module Types
     field :id, ID, null: false
     field :drug_id, ID, null: false
     field :app_no, String, null: false
+    field :drug, Types::DrugType, null: false
 
     def drug
       Loaders::RecordLoader.for(Drug).load(object.drug_id)

--- a/server/app/graphql/types/drug_approval_rating_type.rb
+++ b/server/app/graphql/types/drug_approval_rating_type.rb
@@ -4,14 +4,14 @@ module Types
     field :drug_id, ID, null: false
     field :rating, String, null: false
     field :drug, Types::DrugType, null: false
-    field :sources, [Types::SourceType], null: false
+    field :source, Types::SourceType, null: false
 
     def drug
       Loaders::RecordLoader.for(Drug).load(object.drug_id)
     end
 
-    def sources
-      Loaders::AssociationLoader.for(DrugApprovalRating, :sources).load(object)
+    def source
+      Loaders::RecordLoader.for(Source).load(object.source_id)
     end
   end
 end

--- a/server/app/graphql/types/drug_approval_rating_type.rb
+++ b/server/app/graphql/types/drug_approval_rating_type.rb
@@ -15,4 +15,3 @@ module Types
     end
   end
 end
-

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -172,7 +172,7 @@ module Types
     end
 
     field :drug_application, Types::DrugApplicationType, null: true do
-      description "Put the description here"
+      description "Drug application"
       argument :id, ID, required: true
     end
 
@@ -181,7 +181,7 @@ module Types
     end
 
     field :drug_approval_rating, Types::DrugApprovalRatingType, null: true do
-      description "Put the description here"
+      description "Drug approval rating"
       argument :id, ID, required: true
     end
 

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -171,6 +171,24 @@ module Types
       DrugClaim.find_by(id: id)
     end
 
+    field :drug_application, Types::DrugApplicationType, null: true do
+      description "Put the description here"
+      argument :id, ID, required: true
+    end
+
+    def drug_application(id:)
+      DrugApplication.find_by(id: id)
+    end
+
+    field :drug_approval_rating, Types::DrugApprovalRatingType, null: true do
+      description "Put the description here"
+      argument :id, ID, required: true
+    end
+
+    def drug_approval_rating(id:)
+      DrugApprovalRating.find_by(id: id)
+    end
+
     field :drug, Types::DrugType, null: true do
       description "A drug"
       argument :id, ID, required: true


### PR DESCRIPTION
fixes #218 
Fixed a few fields on `DrugApplicationType` and `DrugApprovalRatingType` and made them available as top level queries.
I should note that I did not need to make any changes to the code to get the fields to return values with the example query provided in #218