### PR TITLE
Fixed DrugBank Importer Fetching Blank Values

### DIFF
--- a/server/app/models/drug_claim.rb
+++ b/server/app/models/drug_claim.rb
@@ -9,6 +9,8 @@ class DrugClaim < ::ActiveRecord::Base
   has_many :drug_claim_attributes, inverse_of: :drug_claim, dependent: :delete_all
   has_many :drug_claim_approval_ratings, inverse_of: :drug_claim, dependent: :delete_all
 
+  validates :name, presence: true, allow_blank: false
+
   def self.for_search
     eager_load(
       drug: [

--- a/server/lib/genome/importers/base.rb
+++ b/server/lib/genome/importers/base.rb
@@ -108,7 +108,7 @@ module Genome
           name: name.strip,
           nomenclature: nomenclature.strip,
           source_id: source.id
-        ).first_or_create
+        ).first_or_create!
       end
 
       def create_drug_claim_alias(drug_claim, synonym, nomenclature)

--- a/server/lib/genome/importers/file_importers/drugbank.rb
+++ b/server/lib/genome/importers/file_importers/drugbank.rb
@@ -120,7 +120,9 @@ module Genome; module Importers; module FileImporters; module Drugbank;
         when 'drugbank-id'
             if attrs['primary']
                 @drugbank_id_flag = true
-                @is_primary_drug = true
+                if @is_not_salts
+                    @is_primary_drug = true
+                end
             end
 
         when 'name'
@@ -185,14 +187,14 @@ module Genome; module Importers; module FileImporters; module Drugbank;
         if @target_name_flag
             if @is_target
                 @target_name_flag = false
-                @current_target_name = string
+                @current_target_name = string unless string.strip == ""
             end
         end
 
         if target_action_flag
             if is_target
                 @target_action_flag = false
-                @current_target_action = string
+                @current_target_action = string unless string.strip == ""
             end
         end
 


### PR DESCRIPTION
closes #142 
I have fixed the problem of the drugbank importer creating DrugClaims and GeneClaims with blank names and InteractionClaimAttributes with blank values.

The blank name for DrugClaims was a result of a flag in the xml parser incorrectly getting flipped to true. The other two cases were due to not having checks for when their tags of interest were blank. 

This PR adds a validation to the name field on DrugClaim, and changes `first_or_create` to `first_or_create!` in /lib/genome/importers/base.rb for the `create_drug_claim` method. We might also want to consider adding validations to the other fields affected by this issue. If that's desired, I can updated this PR or create a new issue and add it there.