### PR TITLE
Add Query For Ambiguous Matches

### DIFF
--- a/server/app/controllers/graphql_controller.rb
+++ b/server/app/controllers/graphql_controller.rb
@@ -1,4 +1,4 @@
-class GraphqlController < ApplicationController
+class GraphQLController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately

--- a/server/app/graphql/resolvers/genes.rb
+++ b/server/app/graphql/resolvers/genes.rb
@@ -8,7 +8,7 @@ class Resolvers::Genes < GraphQL::Schema::Resolver
 
   scope { Gene.all }
 
-  option(:id, type: ID) { |scope, value| scope.where(id: value)}
+  option(:ids, type: [String]) { |scope, value| scope.where(id: value)}
   option(:name, type: String) { |scope, value| scope.where("name ILIKE ?", "#{value}%")}
   option(:long_name, type: String) { |scope, value| scope.where("long_name ILIKE?", "#{value}%")}
   option(:entrez_id, type: Int) { |scope, value| scope.where(entrez_id: value)}

--- a/server/app/graphql/types/gene_match_type.rb
+++ b/server/app/graphql/types/gene_match_type.rb
@@ -1,0 +1,19 @@
+module Types
+  class SearchMatchType < Types::BaseEnum
+    value 'DIRECT', value: :direct
+    value 'AMBIGUOUS', value: :ambiguous
+    value 'NONE', value: :none
+  end
+
+  class GeneSearchResult < Types::BaseObject
+    field :search_term, String, null: false
+    field :matches, [Types::GeneType], null: false
+    field :match_type, Types::SearchMatchType, null: false
+  end
+
+  class GeneMatchType < Types::BaseObject
+    field :direct_matches, [Types::GeneSearchResult], null: false
+    field :ambiguous_matches, [Types::GeneSearchResult], null: false
+    field :no_matches, [Types::GeneSearchResult], null: false
+  end
+end

--- a/server/app/graphql/types/queries/gene_lookup_query.rb
+++ b/server/app/graphql/types/queries/gene_lookup_query.rb
@@ -1,0 +1,78 @@
+module Types::Queries
+  module GeneLookupQuery
+    def self.included(klass)
+      klass.field :gene_matches, Types::GeneMatchType, null: false do
+        description "Match Gene search terms to known Entrez Genes in the database."
+        argument :search_terms, [GraphQL::Types::String], required: true
+      end
+
+      def gene_matches(search_terms: )
+        remaining_terms = Set.new(search_terms)
+
+        results = {
+          direct_matches: [],
+          ambiguous_matches: [],
+          no_matches: []
+        }
+
+        #find exact matches on gene smybol
+        direct_symbol_matches = Gene.where('name in (?)', remaining_terms)
+        direct_symbol_matches.each do |g| 
+          results[:direct_matches] << {
+            search_term: g.name,
+            matches: [g],
+            match_type: :direct
+          }
+        end
+        remaining_terms = remaining_terms - direct_symbol_matches.map(&:name)
+
+        #find exact matches on entrez id
+        terms_as_entrez_ids = remaining_terms.map { |term| Integer(term) rescue nil }.compact
+        
+        if terms_as_entrez_ids.size > 0
+          direct_entrez_id_matches = Gene.where('concept_id in (?)', terms_as_entrez_ids)
+          direct_entrez_id_matches.each do |g| 
+            results[:direct_matches] << {
+              search_term: g.entrez_id,
+              matches: [g],
+              match_type: :direct
+            }
+          end
+          remaining_terms = remaining_terms - direct_matches.map(&:entrez_id)
+        end
+
+        #find matches through aliases
+        alias_matches = GeneAlias.eager_load(:gene)
+          .where(alias: remaining_terms)
+          .group_by(&:alias)
+
+        alias_matches.each do |term, matches|
+
+          key = if matches.size == 1
+                  'direct'
+                else
+                  'ambiguous'
+                end
+
+          results["#{key}_matches".to_sym] << {
+            search_term: term,
+            matches: matches.map(&:gene),
+            match_type: key.to_sym
+          }
+        end
+        remaining_terms = remaining_terms - alias_matches.map { |term, _| term }
+
+        #what still remains is unmatched
+        remaining_terms.each do |term|
+          results[:no_matches] << {
+            search_term: term,
+            matches: [],
+            match_type: :no_matches
+          }
+        end
+
+        results
+      end
+    end
+  end
+end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -4,10 +4,13 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
+    include Types::Queries::GeneLookupQuery
+
     field :genes, resolver: Resolvers::Genes
     field :drugs, resolver: Resolvers::Drugs
     field :sources, resolver: Resolvers::Sources
     field :categories, resolver: Resolvers::Categories
+
 
     field :source, Types::SourceType, null: true do
       description "A source"
@@ -61,15 +64,6 @@ module Types
 
     def drug(name: )
       Drug.find_by(name: name)
-    end
-
-    field :genes, [Types::GeneType], null: false do
-      description "A gene"
-      argument :name, [String], required: true
-    end
-
-    def genes(name: )
-      Gene.where(name: name)
     end
 
     field :drugs, [Types::DrugType], null: false do

--- a/server/db/migrate/20230104221712_add_indexes.rb
+++ b/server/db/migrate/20230104221712_add_indexes.rb
@@ -1,0 +1,6 @@
+class AddIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :genes, :name
+    add_index :gene_aliases, :alias
+  end
+end


### PR DESCRIPTION
After playing with a couple of different implementations, this seems like the best approach to power the type of UI we want, but I'm obviously open to feedback!

Essentially now it will be a two query approach. First there is a new `geneMatches` query that takes search terms. This will take your search terms and perform the bucketing into direct, ambiguous, and unmatched terms. From this response you can retrieve the search terms, what type of match they were, and what genes they matched. Most importantly you can get a list of gene IDs.

The `genes` query now optionally accepts a list of Gene IDs as an argument in addition to the existing filters and automatically paginates.

In this way you can imagine running the initial query, getting two lists of gene ids, and then each tab can hit the `genes` query with its own list of ids and display a paginated list of interactions. Furthermore you have sufficient information from the first query to display a summary of matches in the sidebar like we do in the old version should you wish.

An example query with the new endpoint, using the test list from current DGIdb:

```
{
  geneMatches(searchTerms: ["FLT1", "FLT2", "FLT3", "STK1", "MM1", "AQP9", "LOC100508755", "FAKE1"]) {
    directMatches {
      searchTerm
      matches {
        id
        name
      }
    }
    ambiguousMatches {
      searchTerm
      matches {
        id
        name
      }
    }
    noMatches {
      searchTerm
    }
  }
}
```

and its result:

```
{
  "data": {
    "geneMatches": {
      "directMatches": [
        {
          "searchTerm": "AQP9",
          "matches": [
            {
              "id": "dbf0b854-0a06-4132-b66a-48275bed2863",
              "name": "AQP9"
            }
          ]
        },
        {
          "searchTerm": "FLT1",
          "matches": [
            {
              "id": "5c60a645-e13e-4236-8aaf-5879bd44993e",
              "name": "FLT1"
            }
          ]
        },
        {
          "searchTerm": "FLT3",
          "matches": [
            {
              "id": "da8f92ee-a04c-4677-b08e-2c8be0a985df",
              "name": "FLT3"
            }
          ]
        },
        {
          "searchTerm": "FLT2",
          "matches": [
            {
              "id": "df6ec87e-1809-45f8-b7c0-493f6b0306fe",
              "name": "FGFR1"
            }
          ]
        }
      ],
      "ambiguousMatches": [
        {
          "searchTerm": "STK1",
          "matches": [
            {
              "id": "b118f8c1-9b65-4ec6-9f67-f306707ded75",
              "name": "CDK7"
            },
            {
              "id": "da8f92ee-a04c-4677-b08e-2c8be0a985df",
              "name": "FLT3"
            },
            {
              "id": "89e2840d-029b-4d53-a5ae-132d6a273d09",
              "name": "AURKB"
            }
          ]
        },
        {
          "searchTerm": "MM1",
          "matches": [
            {
              "id": "2f2872ab-2bf1-4512-a409-c25058a09aa5",
              "name": "PFDN5"
            },
            {
              "id": "3dd31004-1afa-4918-8c4e-98e8ef2b0e4e",
              "name": "PLXNB2"
            }
          ]
        }
      ],
      "noMatches": [
        {
          "searchTerm": "LOC100508755"
        },
        {
          "searchTerm": "FAKE1"
        }
      ]
    }
  }
}
```

Let me know if this makes sense or what thoughts you have. Also happy to jump on a call and discuss. I can also take stab at the frontend implementation if that would be easier.

