### PR TITLE
refactor: use resolver method to avoid namespace collisions for :alias

### DIFF
--- a/server/app/graphql/types/drug_alias_type.rb
+++ b/server/app/graphql/types/drug_alias_type.rb
@@ -1,13 +1,17 @@
 module Types
   class DrugAliasType < Types::BaseObject
     field :id, ID, null: false
-    field :alias, String, null: false
+    field :alias, String, null: false, resolver_method: :resolve_alias
     field :drug_id, ID, null: false
     field :drug, Types::DrugType, null: false
     field :sources, [Types::SourceType], null: false
 
     def drug
       Loaders::RecordLoader.for(Drug).load(object.drug_id)
+    end
+
+    def resolve_alias
+      object.alias
     end
 
     def sources

--- a/server/app/graphql/types/drug_claim_alias_type.rb
+++ b/server/app/graphql/types/drug_claim_alias_type.rb
@@ -2,12 +2,16 @@ module Types
   class DrugClaimAliasType < Types::BaseObject
     field :id, ID, null: false
     field :drug_claim_id, ID, null: false
-    field :alias, String, null: false
+    field :alias, String, null: false, resolver_method: :resolve_alias
     field :nomenclature, String, null: false
     field :drug_claim, Types::DrugClaimType, null: false
 
     def drug_claim
       Loaders::RecordLoader.for(DrugClaim).load(object.drug_claim_id)
+    end
+
+    def resolve_alias
+      object.alias
     end
   end
 end

--- a/server/app/graphql/types/gene_alias_type.rb
+++ b/server/app/graphql/types/gene_alias_type.rb
@@ -2,13 +2,17 @@ module Types
   class GeneAliasType < Types::BaseObject
     field :id, ID, null: false
     field :gene_id, ID, null: false
-    field :alias, String, null: false
+    field :alias, String, null: false, resolver_method: :resolve_alias
 
     field :gene, Types::GeneType, null: false
     field :sources, [Types::SourceType], null: false
 
     def gene
       Loaders::RecordLoader.for(Gene).load(object.gene_id)
+    end
+
+    def resolve_alias
+      object.alias
     end
 
     def sources

--- a/server/app/graphql/types/gene_claim_alias_type.rb
+++ b/server/app/graphql/types/gene_claim_alias_type.rb
@@ -2,10 +2,14 @@ module Types
   class GeneClaimAliasType < Types::BaseObject
     field :id, ID, null: false
     field :gene_claim_id, ID, null: false
-    field :alias, String, null: false
+    field :alias, String, null: false, resolver_method: :resolve_alias
     field :nomenclature, String, null: false
 
     field :gene_claim, Types::GeneClaimType, null: false
+
+    def resolve_alias
+      object.alias
+    end
 
     def gene_claim
       Loaders::RecordLoader.for(GeneClaim).load(object.gene_claim_id)


### PR DESCRIPTION
Make these things go away:

```
DrugAlias's `field :alias` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_alias` and `def resolve_alias`). Or use `method_
conflict_warning: false` to suppress this warning.
```