### PR TITLE
fix: temporarily block complex molecular profiles in CIViC

### DIFF
--- a/server/lib/genome/importers/api_importers/civic/api_client.rb
+++ b/server/lib/genome/importers/api_importers/civic/api_client.rb
@@ -44,6 +44,9 @@ module Genome; module Importers; module ApiImporters; module Civic
               }
               molecularProfiles {
                 nodes {
+                  variants {
+                    id
+                  }
                   evidenceItems {
                     nodes {
                       name

--- a/server/lib/genome/importers/api_importers/civic/importer.rb
+++ b/server/lib/genome/importers/api_importers/civic/importer.rb
@@ -79,7 +79,7 @@ module Genome
           def create_interaction_claims
             api_client = ApiClient.new
             api_client.enumerate_variants.each do |variant_edge|
-              mp_nodes = variant_edge.node.molecular_profiles.nodes
+              mp_nodes = variant_edge.node.molecular_profiles.nodes.select { |mp| mp.variants.size == 1 }
               ei_nodes = mp_nodes.reduce([]) { |tot, node| tot.concat(node.evidence_items.nodes) }
               ei_nodes = ei_nodes.select { |ei| importable_eid?(ei) }
               next if ei_nodes.length.zero?


### PR DESCRIPTION
Per #265  -- temporarily(?) don't import any molecular profiles that contain multiple variations