### PR TITLE
Add drug name matching query

### DIFF
--- a/server/app/graphql/resolvers/drugs.rb
+++ b/server/app/graphql/resolvers/drugs.rb
@@ -9,7 +9,7 @@ class Resolvers::Drugs < GraphQL::Schema::Resolver
 
   scope { Drug.all }
 
-  option(:id, type: ID, description: 'Exact match filtering on the ID of the drug.') do |scope, value|
+  option(:ids, type: [String], description: 'Exact match filtering on a list of drug IDs') do |scope, value|
     scope.where(id: value)
   end
 

--- a/server/app/graphql/types/drug_match_type.rb
+++ b/server/app/graphql/types/drug_match_type.rb
@@ -1,0 +1,13 @@
+module Types
+  class DrugSearchResult < Types::BaseObject
+    field :search_term, String, null: false
+    field :matches, [Types::DrugType], null: false
+    field :match_type, Types::SearchMatchType, null: false
+  end
+
+  class DrugMatchType < Types::BaseObject
+    field :direct_matches, [Types::DrugSearchResult], null: false
+    field :ambiguous_matches, [Types::DrugSearchResult], null: false
+    field :no_matches, [Types::DrugSearchResult], null: false
+  end
+end

--- a/server/app/graphql/types/gene_match_type.rb
+++ b/server/app/graphql/types/gene_match_type.rb
@@ -1,10 +1,4 @@
 module Types
-  class SearchMatchType < Types::BaseEnum
-    value 'DIRECT', value: :direct
-    value 'AMBIGUOUS', value: :ambiguous
-    value 'NONE', value: :none
-  end
-
   class GeneSearchResult < Types::BaseObject
     field :search_term, String, null: false
     field :matches, [Types::GeneType], null: false

--- a/server/app/graphql/types/queries/drug_lookup_query.rb
+++ b/server/app/graphql/types/queries/drug_lookup_query.rb
@@ -1,0 +1,76 @@
+module Types::Queries
+  module DrugLookupQuery
+    def self.included(klass)
+      klass.field :drug_matches, Types::DrugMatchType, null: false do
+        description "Match Drug search terms to known drugs in the database."
+        argument :search_terms, [GraphQL::Types::String], required: true
+      end
+
+      def drug_matches(search_terms: )
+        remaining_terms = Set.new(search_terms)
+
+        results = {
+          direct_matches: [],
+          ambiguous_matches: [],
+          no_matches: []
+        }
+
+        #find exact matches on drug name 
+        direct_symbol_matches = Drug.where(name: remaining_terms)
+        direct_symbol_matches.each do |d|
+          results[:direct_matches] << {
+            search_term: d.name,
+            matches: [d],
+            match_type: :direct
+          }
+        end
+        remaining_terms -= direct_symbol_matches.map(&:name)
+
+        #find exact matches on concept ID
+        if remaining_terms.size.positive?
+          direct_id_matches = Drug.where(concept_id: remaining_terms)
+          direct_id_matches.each do |d|
+            results[:direct_matches] << {
+              search_term: d.concept_id,
+              matches: [d],
+              match_type: :direct
+            }
+          end
+          remaining_terms -= direct_id_matches.map(&:concept_id)
+        end
+
+        #find matches through aliases
+        alias_matches = DrugAlias.eager_load(:drug)
+          .where(alias: remaining_terms)
+          .group_by(&:alias)
+
+        alias_matches.each do |term, matches|
+
+          key = if matches.size == 1
+                  'direct'
+                else
+                  'ambiguous'
+                end
+
+          results["#{key}_matches".to_sym] << {
+            search_term: term,
+            matches: matches.map(&:drug),
+            match_type: key.to_sym
+          }
+        end
+        remaining_terms -= alias_matches.map { |term, _| term }
+
+        #what still remains is unmatched
+        remaining_terms.each do |term|
+          results[:no_matches] << {
+            search_term: term,
+            matches: [],
+            match_type: :no_matches
+          }
+        end
+
+        results
+      end
+    end
+  end
+end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -5,6 +5,7 @@ module Types
     include GraphQL::Types::Relay::HasNodesField
 
     include Types::Queries::GeneLookupQuery
+    include Types::Queries::DrugLookupQuery
 
     field :genes, resolver: Resolvers::Genes
     field :drugs, resolver: Resolvers::Drugs

--- a/server/app/graphql/types/search_match_type.rb
+++ b/server/app/graphql/types/search_match_type.rb
@@ -1,0 +1,7 @@
+module Types
+  class SearchMatchType < Types::BaseEnum
+    value 'DIRECT', value: :direct
+    value 'AMBIGUOUS', value: :ambiguous
+    value 'NONE', value: :none
+  end
+end

--- a/server/spec/queries/drug_matches_query_spec.rb
+++ b/server/spec/queries/drug_matches_query_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe 'Drug query matching', type: :graphql do
+  before(:example) do
+    @direct_name = create(:drug, name: 'DIRECT_NAME', concept_id: '123')
+    @direct_concept_id = create(:drug, name: 'Drug 2', concept_id: 'DIRECT_CONCEPT_ID')
+
+    @ambiguous_alias_1 = create(:drug_alias, alias: 'SHARED_ALIAS')
+    @ambiguous_alias_2 = create(:drug_alias, alias: 'SHARED_ALIAS')
+
+    @ambiguous_drug_1 = create(:drug, name: 'AMBIGUOUS_DRUG_1', drug_aliases: [@ambiguous_alias_1])
+    @ambiguous_drug_2 = create(:drug, name: 'AMBIGUOUS_DRUG_2', drug_aliases: [@ambiguous_alias_2])
+
+    @fake_drug = 'FAKE1'
+  end
+
+  let :query do
+    <<-GRAPHQL
+    query drugMatches($searchTerms: [String!]!) {
+
+      drugMatches(searchTerms: $searchTerms) {
+        directMatches {
+          searchTerm
+          matches {
+            id
+            name
+          }
+        }
+        ambiguousMatches {
+          searchTerm
+          matches {
+            id
+            name
+          }
+        }
+        noMatches {
+          searchTerm
+        }
+      }
+    }
+    GRAPHQL
+  end
+
+  it 'should return the expected matches' do
+    search_terms = [
+      @direct_name.name, #direct match by drug name
+      @direct_concept_id.concept_id,  # direct match by concept id
+      @ambiguous_alias_1.alias, #ambiguous match by alias
+      @fake_drug # no match
+    ]
+    result = execute_graphql(query, variables: { searchTerms: search_terms })
+
+    direct_matches = result['data']['drugMatches']['directMatches']
+
+    #we got 2 direct matches
+    expect(direct_matches.size).to eq 2
+
+    #each direct match only matches 1 term
+    direct_matches.each do |match|
+      expect(match['matches'].size).to eq 1
+    end
+
+    #we get direct match the two terms we expect to
+    expect(direct_matches.map { |dm| dm['searchTerm'] }.sort).to eq([@direct_name.name, @direct_concept_id.concept_id].sort)
+
+    #we get the expected Drug ID for our concept ID match and name match
+    name_res = direct_matches.select { |dm| dm['searchTerm'] == @direct_name.name }.first['matches'].first['id']
+    expect(name_res).to eq(@direct_name.id)
+    concept_res = direct_matches.select { |dm| dm['searchTerm'] == @direct_concept_id.concept_id }.first['matches'].first['id']
+    expect(concept_res).to eq(@direct_concept_id.id)
+
+    amb_matches = result['data']['drugMatches']['ambiguousMatches']
+
+    #one search term should match ambiguously
+    expect(amb_matches.size).to eq 1
+
+    #it should be the term we expect
+    expect(amb_matches.first['searchTerm']).to eq @ambiguous_alias_1.alias
+
+    #that search term should match two drugs
+    expect(amb_matches.first['matches'].size).to eq 2
+
+    #the two drugs should be the ones we expect
+    expect(amb_matches.first['matches'].map { |m| m['id'] }.sort).to eq [@ambiguous_drug_1.id, @ambiguous_drug_2.id].sort
+
+
+    #our fake drug shouldn't match
+    no_matches = result['data']['drugMatches']['noMatches']
+    expect(no_matches.size).to eq 1
+    expect(no_matches.map { |nm| nm['searchTerm'] }).to eq([@fake_drug])
+  end
+end


### PR DESCRIPTION
Essentially identical to the Gene matching query, run one query to bucket the search terms into match types and get the IDs of the matched drugs, then query the `drugs` endpoint with the list of IDs.

Example query:

```
{
  drugMatches(searchTerms: ["SUNITINIB", "ZALCITABINE", "LINCOCIN", "TRASTUZUMAB", "PHLORETIN", "NOTREAL"]) {
    directMatches {
      searchTerm
      matches {
        id
        name
      }
    }
    ambiguousMatches {
      searchTerm
      matches {
        id
        name
      }
    }
    noMatches {
      searchTerm
    }
  }
}
```