### PR TITLE
fix: update Pharos graphql query

### DIFF
--- a/server/lib/genome/importers/api_importers/pharos/api_client.rb
+++ b/server/lib/genome/importers/api_importers/pharos/api_client.rb
@@ -4,9 +4,6 @@ require 'open-uri'
 
 module Genome; module Importers; module ApiImporters; module Pharos;
   class ApiClient
-    categories_to_get = ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
-    category = categories_to_get.pop
-
     def enumerate_genes(category)
       skip = 0
       top = 50

--- a/server/lib/genome/importers/api_importers/pharos/api_client.rb
+++ b/server/lib/genome/importers/api_importers/pharos/api_client.rb
@@ -1,33 +1,68 @@
+require "graphql/client"
+require "graphql/client/http"
 require 'open-uri'
 
 module Genome; module Importers; module ApiImporters; module Pharos;
   class ApiClient
-    def genes_for_category(category, start = 0, count = 10)
-      get_entries(gene_lookup_base_url, category, start, count)
-    end
-
-    def get_entries(url, category, start, count)
-      uri = URI.parse(url).tap do |u|
-        u.query = URI.encode_www_form(params(category, start, count))
+    def enumerate_genes
+      categories_to_get = ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
+      category = categories_to_get.pop
+      skip = 0
+      top = 50
+      genes = send_query(category, skip, top)
+      Enumerator.new do |y|
+        until genes.empty? and categories_to_get.empty?
+          puts genes.size
+          puts category
+          skip += genes.size
+          genes.each { |gene| y << gene }
+          genes = send_query(category, skip, top)
+          if genes.empty?
+            category = categories_to_get.pop
+            skip = 0
+          end
+        end
       end
-      body = make_get_request(uri)
-      JSON.parse(body)['data']['search']['targetResult']['targets']
     end
 
-    def make_get_request(uri)
-      res = Net::HTTP.get_response(uri)
-      raise StandardError, 'Request Failed!' unless res.code == '200'
-      res.body
+    private
+
+    module PharosApi
+      endpoint = 'https://pharos-api.ncats.io/graphql'
+      HTTP = GraphQL::Client::HTTP.new(endpoint) do
+        def headers(_context)
+          { 'User-Agent': 'DGIdb.org Pharos importer' }
+        end
+      end
+
+      Schema = GraphQL::Client.load_schema(HTTP)
+      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
     end
 
-    def gene_lookup_base_url
-      'https://pharos-api.ncats.io/graphql'
-    end
-
-    def params(category, start, count)
-      {
-        'query' => "{search(term:\"#{category}\",facets:\"Family\"){targetResult{targets(skip:#{start},top:#{count}){uniprot,name,sym}}}}"
+    Query = PharosApi::Client.parse <<-GRAPHQL
+      query($filter: IFilter, $skip: Int, $top: Int) {
+        targets(filter: $filter) {
+          targets(skip: $skip, top: $top) {
+            uniprot
+            name
+            sym
+            fam
+            preferredSymbol
+            facetValues(facetName: "IDG Family")
+          }
+        }
       }
+    GRAPHQL
+
+    def send_query(category, skip, top)
+      response = PharosApi::Client.query(Query, variables: {
+        'filter': {
+          'term': category
+        },
+        'skip': skip,
+        'top': top
+      })
+      response.data.targets.targets
     end
   end
 end; end; end; end

--- a/server/lib/genome/importers/api_importers/pharos/api_client.rb
+++ b/server/lib/genome/importers/api_importers/pharos/api_client.rb
@@ -4,23 +4,18 @@ require 'open-uri'
 
 module Genome; module Importers; module ApiImporters; module Pharos;
   class ApiClient
-    def enumerate_genes
-      categories_to_get = ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
-      category = categories_to_get.pop
+    categories_to_get = ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
+    category = categories_to_get.pop
+
+    def enumerate_genes(category)
       skip = 0
       top = 50
       genes = send_query(category, skip, top)
       Enumerator.new do |y|
-        until genes.empty? and categories_to_get.empty?
-          puts genes.size
-          puts category
+        until genes.empty?
           skip += genes.size
           genes.each { |gene| y << gene }
           genes = send_query(category, skip, top)
-          if genes.empty?
-            category = categories_to_get.pop
-            skip = 0
-          end
         end
       end
     end
@@ -48,7 +43,6 @@ module Genome; module Importers; module ApiImporters; module Pharos;
             sym
             fam
             preferredSymbol
-            facetValues(facetName: "IDG Family")
           }
         }
       }

--- a/server/lib/genome/importers/api_importers/pharos/importer.rb
+++ b/server/lib/genome/importers/api_importers/pharos/importer.rb
@@ -29,51 +29,30 @@ module Genome; module Importers; module ApiImporters; module Pharos;
       @source.save
     end
 
-    # Pharos likes to time out -- trying smaller and smaller requests seems to work more reliably
-    def perform_safe_lookup(api_client, category, start, count)
-      raise Net::ReadTimeout if count < 10  # arbitrary threshold - could revise if needed
-
-      begin
-        genes = api_client.genes_for_category(category, start, count)
-      rescue Net::ReadTimeout
-        return perform_safe_lookup(api_client, category, start, count / 2)
-      end
-      [genes, count]
+    def categories
+      ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
     end
 
     def create_gene_claims
       api_client = ApiClient.new
-      categories.each do |category|
-        start = 0
+      api_client.enumerate_genes.each do |gene|
+        puts gene.facetValues
+        category = gene.fam.upcase
+        next if gene.sym.nil? or !categories.include?(category)
 
-        loop do
-          lookup_result = perform_safe_lookup(api_client, category, start, 100)
-          genes = lookup_result[0]
-          break unless genes.size.positive?
-
-          genes.each do |gene|
-            next if gene['sym'].nil?
-
-            gene_claim = create_gene_claim(gene['sym'], GeneNomenclature::SYMBOL)
-            create_gene_claim_alias(gene_claim, gene['name'], GeneNomenclature::NAME)
-            create_gene_claim_alias(gene_claim, "uniprot:#{gene['uniprot']}", GeneNomenclature::UNIPROTKB_ID)
-            normalized_category = case category
-                                  when 'GPCR'
-                                    'G PROTEIN COUPLED RECEPTOR'
-                                  when 'Nuclear Receptor'
-                                    'NUCLEAR HORMONE RECEPTOR'
-                                  else
-                                    category.upcase
-                                  end
-            create_gene_claim_category(gene_claim, normalized_category)
-          end
-          start += lookup_result[1]
-        end
+        gene_claim = create_gene_claim(gene.sym, GeneNomenclature::SYMBOL)
+        create_gene_claim_alias(gene_claim, gene.name, GeneNomenclature::NAME)
+        create_gene_claim_alias(gene_claim, "uniprot:#{gene.uniprot}", GeneNomenclature::UNIPROTKB_ID)
+        normalized_category = case category
+                              when 'GPCR'
+                                'G PROTEIN COUPLED RECEPTOR'
+                              when 'Nuclear Receptor'
+                                'NUCLEAR HORMONE RECEPTOR'
+                              else
+                                category.upcase
+                              end
+        create_gene_claim_category(gene_claim, normalized_category)
       end
-    end
-
-    def categories
-      ['Enzyme', 'Transcription Factor', 'Kinase', 'Transporter', 'GPCR', 'Ion Channel', 'Nuclear Receptor']
     end
   end
 end; end; end; end

--- a/server/lib/genome/importers/api_importers/pharos/importer.rb
+++ b/server/lib/genome/importers/api_importers/pharos/importer.rb
@@ -30,28 +30,28 @@ module Genome; module Importers; module ApiImporters; module Pharos;
     end
 
     def categories
-      ['ENZYME', 'TRANSCRIPTION FACTOR', 'KINASE', 'TRANSPORTER', 'GPCR', 'ION CHANNEL', 'NUCLEAR RECEPTOR']
+      ['Enzyme', 'Transcription Factor', 'Kinase', 'Transporter', 'GPCR', 'Ion Channel', 'Nuclear Receptor']
     end
 
     def create_gene_claims
       api_client = ApiClient.new
-      api_client.enumerate_genes.each do |gene|
-        puts gene.facetValues
-        category = gene.fam.upcase
-        next if gene.sym.nil? or !categories.include?(category)
+      categories.each do |category|
+        api_client.enumerate_genes(category).each do |gene|
+          next if gene.sym.nil?
 
-        gene_claim = create_gene_claim(gene.sym, GeneNomenclature::SYMBOL)
-        create_gene_claim_alias(gene_claim, gene.name, GeneNomenclature::NAME)
-        create_gene_claim_alias(gene_claim, "uniprot:#{gene.uniprot}", GeneNomenclature::UNIPROTKB_ID)
-        normalized_category = case category
-                              when 'GPCR'
-                                'G PROTEIN COUPLED RECEPTOR'
-                              when 'Nuclear Receptor'
-                                'NUCLEAR HORMONE RECEPTOR'
-                              else
-                                category.upcase
-                              end
-        create_gene_claim_category(gene_claim, normalized_category)
+          gene_claim = create_gene_claim(gene.sym, GeneNomenclature::SYMBOL)
+          create_gene_claim_alias(gene_claim, gene.name, GeneNomenclature::NAME)
+          create_gene_claim_alias(gene_claim, "uniprot:#{gene.uniprot}", GeneNomenclature::UNIPROTKB_ID)
+          normalized_category = case category
+                                when 'GPCR'
+                                  'G PROTEIN COUPLED RECEPTOR'
+                                when 'Nuclear Receptor'
+                                  'NUCLEAR HORMONE RECEPTOR'
+                                else
+                                  category.upcase
+                                end
+          create_gene_claim_category(gene_claim, normalized_category)
+        end
       end
     end
   end


### PR DESCRIPTION
close #270 

fortunately, it appears that we don't have to use the janky receding-query trick to avoid request timeouts anymore