### PR TITLE
TSV Downloads of Table Contents

### DIFF
--- a/client/src/components/Drug/DrugTable/DrugTable.tsx
+++ b/client/src/components/Drug/DrugTable/DrugTable.tsx
@@ -10,6 +10,7 @@ import './DrugTable.scss';
 import { Skeleton, Table } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import { Box, CircularProgress, Icon } from '@mui/material';
+import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
 
 interface Props {
   searchTerms: string[];
@@ -213,6 +214,7 @@ export const DrugTable: React.FC<Props> = ({searchTerms, displayHeader}) => {
           {interactionResults ? <span id="interaction-count">{interactionResults.length} total interactions</span> : null}
         </span>
       }
+      <TableDownloader tableName='drug_interaction_results' vars={{names: searchTerms}}/>
       <Skeleton loading={!interactionResults.length}>
         <Table
           dataSource={interactionResults}

--- a/client/src/components/Gene/Categories/CategoryResults.tsx
+++ b/client/src/components/Gene/Categories/CategoryResults.tsx
@@ -9,6 +9,7 @@ import { GlobalClientContext } from 'stores/Global/GlobalClient';
 // styles
 import { Tabs } from 'antd';
 import './CategoryResults.scss';
+import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
 
 export const CategoryResults: React.FC = () => {
 
@@ -27,6 +28,7 @@ export const CategoryResults: React.FC = () => {
     <div className="category-results-container">
       <Tabs defaultActiveKey="1" onChange={onChange}>
         <TabPane tab="Unique Matches" key="1">
+        <TableDownloader tableName='gene_category_results' vars={{names: state.searchTerms}}/>
         <div className="gene-categories">
             {genes?.map((gene: any) => {
               return (

--- a/client/src/components/Gene/GeneIntTable/GeneIntTable.tsx
+++ b/client/src/components/Gene/GeneIntTable/GeneIntTable.tsx
@@ -10,6 +10,8 @@ import './GeneIntTable.scss';
 import { Table } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import { Box, CircularProgress, Icon } from '@mui/material';
+import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
+
 
 interface Props {
   searchTerms: string[];
@@ -232,6 +234,7 @@ export const GeneIntTable: React.FC<Props> = ({searchTerms, displayHeader=true})
           <span id='interaction-count'>{interactionResults.length} total interactions</span>
         </span>
       }
+      <TableDownloader tableName='gene_interaction_results' vars={{names: searchTerms}}/>
       <Table
           dataSource={interactionResults}
           columns={columns}

--- a/client/src/components/Shared/TableDownloader/TableDownloader.tsx
+++ b/client/src/components/Shared/TableDownloader/TableDownloader.tsx
@@ -18,10 +18,8 @@ export function TableDownloader<FV>(props: React.PropsWithChildren<Props<FV>>) {
   const [hasError, setHasError] = useState(false);
 
   const onDownloadClick = () => {
-    console.log(process.env)
     setIsLoading(true)
     setHasError(false);
-    console.log(props.vars)
     const options = {
       method: 'POST',
       headers: {

--- a/client/src/components/Shared/TableDownloader/TableDownloader.tsx
+++ b/client/src/components/Shared/TableDownloader/TableDownloader.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import DownloadIcon from '@mui/icons-material/Download';
+
+import { API_URL } from 'config';
+import Box from '@mui/material/Box';
+
+interface Props<FilterVars> {
+  tableName: string;
+  vars: FilterVars
+}
+
+export function TableDownloader<FV>(props: React.PropsWithChildren<Props<FV>>) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const onDownloadClick = () => {
+    console.log(process.env)
+    setIsLoading(true)
+    setHasError(false);
+    console.log(props.vars)
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({variables: props.vars})
+    }
+    fetch(`${API_URL}/download/${props.tableName}`, options).then(resp => {
+      if (resp.ok) {
+        resp.blob().then(blob => {
+          const fileUrl =  window.URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = fileUrl
+          a.style.display = 'none';
+          a.download = `${props.tableName}-${new Date().toLocaleString().split(',')[0]}.tsv`;
+          document.body.append(a);
+          a.click();
+          setTimeout(() => { window.URL.revokeObjectURL(fileUrl); }, 400);
+          setIsLoading(false);
+        })
+      } else {
+        setIsLoading(false)
+        setHasError(true)
+      }
+    })
+  }
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Button variant="outlined" 
+        endIcon={<DownloadIcon />}
+        disabled={isLoading}
+        onClick={onDownloadClick}>
+        Download
+      </Button>
+      { isLoading && <CircularProgress/> }
+      { hasError && <Alert severity='error'
+                      onClose={() => {setHasError(false)}}>
+                        There was an error downloading the file.
+                      </Alert>}
+    </Box>
+  )
+}
+
+export default TableDownloader;

--- a/server/app/controllers/application_controller.rb
+++ b/server/app/controllers/application_controller.rb
@@ -1,2 +1,23 @@
 class ApplicationController < ActionController::API
+
+  private
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
 end

--- a/server/app/controllers/graphql_controller.rb
+++ b/server/app/controllers/graphql_controller.rb
@@ -19,28 +19,8 @@ class GraphqlController < ApplicationController
     handle_error_in_development(e)
   end
 
+
   private
-
-  # Handle variables in form data, JSON body, or a blank value
-  def prepare_variables(variables_param)
-    case variables_param
-    when String
-      if variables_param.present?
-        JSON.parse(variables_param) || {}
-      else
-        {}
-      end
-    when Hash
-      variables_param
-    when ActionController::Parameters
-      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
-    when nil
-      {}
-    else
-      raise ArgumentError, "Unexpected parameter: #{variables_param}"
-    end
-  end
-
   def handle_error_in_development(e)
     logger.error e.message
     logger.error e.backtrace.join("\n")

--- a/server/app/controllers/table_download_controller.rb
+++ b/server/app/controllers/table_download_controller.rb
@@ -1,19 +1,24 @@
 class TableDownloadController < ApplicationController
 
   @@table_resolvers = {
-    gene_interaction_results: Resolvers::Genes
+    gene_interaction_results: [Resolvers::Genes, GeneInteractionsTsv],
+    drug_interaction_results: [Resolvers::Drugs, DrugInteractionsTsv],
+    gene_category_results: [Resolvers::Genes, GeneCategoriesTsv]
   }
 
   def download_table
-    if res = @@table_resolvers[params[:table_name].to_sym]
-      stream_table(resolver: res)
+    table_name = params[:table_name].to_sym
+
+    if @@table_resolvers.has_key?(table_name)
+      res, mapper = @@table_resolvers[table_name]
+      stream_table(resolver: res, mapper: mapper)
     else
       head :bad_request
     end
   end
 
   private
-  def stream_table(resolver: )
+  def stream_table(resolver: , mapper:)
     variables = prepare_variables(params[:variables])
     variables.delete('sortBy')
     variables.transform_keys! { |k| GraphQL::Schema::Member::BuildType.underscore(k) }
@@ -27,9 +32,9 @@ class TableDownloadController < ApplicationController
     response.status = 200
 
     self.response_body = Enumerator.new do |collection|
-      collection << CSV.generate_line(resolver.table_headers, col_sep: "\t")
+      collection << CSV.generate_line(mapper.table_headers, col_sep: "\t")
       resolver.new(filters: variables).results.find_each(batch_size: 250) do |result|
-        Array(resolver.to_row(object: result)).each do |row|
+        Array(mapper.to_row(object: result)).each do |row|
           collection << CSV.generate_line(row, col_sep: "\t")
         end
       end

--- a/server/app/controllers/table_download_controller.rb
+++ b/server/app/controllers/table_download_controller.rb
@@ -1,0 +1,38 @@
+class TableDownloadController < ApplicationController
+
+  @@table_resolvers = {
+    gene_interaction_results: Resolvers::Genes
+  }
+
+  def download_table
+    if res = @@table_resolvers[params[:table_name].to_sym]
+      stream_table(resolver: res)
+    else
+      head :bad_request
+    end
+  end
+
+  private
+  def stream_table(resolver: )
+    variables = prepare_variables(params[:variables])
+    variables.delete('sortBy')
+    variables.transform_keys! { |k| GraphQL::Schema::Member::BuildType.underscore(k) }
+
+    headers.delete("Content-Length")
+    headers["Cache-Control"] = "no-cache"
+    headers["Content-Type"] = "text/csv"
+    headers["Content-Disposition"] = "attachment; filename=\"#{params[:action]}-#{Date.today}.tsv\""
+    headers["X-Accel-Buffering"] = "no"
+
+    response.status = 200
+
+    self.response_body = Enumerator.new do |collection|
+      collection << CSV.generate_line(resolver.table_headers, col_sep: "\t")
+      resolver.new(filters: variables).results.find_each(batch_size: 250) do |result|
+        Array(resolver.to_row(object: result)).each do |row|
+          collection << CSV.generate_line(row, col_sep: "\t")
+        end
+      end
+    end
+  end
+end

--- a/server/app/graphql/resolvers/genes.rb
+++ b/server/app/graphql/resolvers/genes.rb
@@ -35,30 +35,4 @@ class Resolvers::Genes < GraphQL::Schema::Resolver
   option(:pmid, type: Int, description: 'Exact match filtering on publication pmids.') do |scope, value|
     scope.joins(interactions: :publications).where("publications.pmid = ?", value)
   end
-
-  def self.table_headers
-    [
-      'gene',
-      'drug',
-      'regulatory approval',
-      'indication',
-      'interaction score'
-    ]
-  end
-
-  def self.to_row(object: )
-    object.interactions.includes(drug: [:drug_attributes]).map do |i|
-      [
-        object.name,
-        i.drug.name,
-        i.drug.approved ? 'Approved' : 'Not Approved',
-        i.drug.drug_attributes
-          .select { |da| da.name == 'Drug Indications' }
-          .map(&:value)
-          .join(','),
-        i.interaction_score
-      ]
-    end
-  end
-  
 end

--- a/server/app/graphql/resolvers/genes.rb
+++ b/server/app/graphql/resolvers/genes.rb
@@ -35,4 +35,30 @@ class Resolvers::Genes < GraphQL::Schema::Resolver
   option(:pmid, type: Int, description: 'Exact match filtering on publication pmids.') do |scope, value|
     scope.joins(interactions: :publications).where("publications.pmid = ?", value)
   end
+
+  def self.table_headers
+    [
+      'gene',
+      'drug',
+      'regulatory approval',
+      'indication',
+      'interaction score'
+    ]
+  end
+
+  def self.to_row(object: )
+    object.interactions.includes(drug: [:drug_attributes]).map do |i|
+      [
+        object.name,
+        i.drug.name,
+        i.drug.approved ? 'Approved' : 'Not Approved',
+        i.drug.drug_attributes
+          .select { |da| da.name == 'Drug Indications' }
+          .map(&:value)
+          .join(','),
+        i.interaction_score
+      ]
+    end
+  end
+  
 end

--- a/server/app/graphql/types/gene_type.rb
+++ b/server/app/graphql/types/gene_type.rb
@@ -19,16 +19,7 @@ module Types
     end
 
     def gene_categories_with_sources (category_name: nil)
-      if category_name
-        GeneClaimCategory.joins(gene_claims: [:source, :gene]).where("genes.id =? ", object.id)
-        .where('gene_claim_categories.name =?', category_name)
-        .select("gene_claim_categories.name, array_agg(distinct(sources.source_db_name)) AS source_names")
-        .group("gene_claim_categories.name")
-      else
-        GeneClaimCategory.joins(gene_claims: [:source, :gene]).where("genes.id =? ", object.id)
-        .select("gene_claim_categories.name, array_agg(distinct(sources.source_db_name)) AS source_names")
-        .group("gene_claim_categories.name")
-      end
+      object.gene_categories_with_sources(category_name: category_name)
     end
 
     def gene_claims

--- a/server/app/models/gene.rb
+++ b/server/app/models/gene.rb
@@ -31,4 +31,17 @@ class Gene < ::ActiveRecord::Base
   def self.for_show
     eager_load(gene_claims: [:gene_claim_aliases, :gene_claim_attributes, :gene, source: [:source_types]])
   end
+
+  def gene_categories_with_sources(category_name: nil)
+    if category_name
+      GeneClaimCategory.joins(gene_claims: [:source, :gene]).where("genes.id =? ", self.id)
+      .where('gene_claim_categories.name =?', category_name)
+      .select("gene_claim_categories.name, array_agg(distinct(sources.source_db_name)) AS source_names")
+      .group("gene_claim_categories.name")
+    else
+      GeneClaimCategory.joins(gene_claims: [:source, :gene]).where("genes.id =? ", self.id)
+      .select("gene_claim_categories.name, array_agg(distinct(sources.source_db_name)) AS source_names")
+      .group("gene_claim_categories.name")
+    end
+  end
 end

--- a/server/app/tsv_exporters/drug_interactions_tsv.rb
+++ b/server/app/tsv_exporters/drug_interactions_tsv.rb
@@ -1,0 +1,21 @@
+class DrugInteractionsTsv
+  def self.table_headers
+    [
+      'drug',
+      'gene',
+      'regulatory approval',
+      'interaction score'
+    ]
+  end
+
+  def self.to_row(object: )
+    object.interactions.includes(:gene).map do |i|
+      [
+        object.name,
+        i.gene.name,
+        object.approved ? 'Approved' : 'Not Approved',
+        i.interaction_score
+      ]
+    end
+  end
+end

--- a/server/app/tsv_exporters/gene_categories_tsv.rb
+++ b/server/app/tsv_exporters/gene_categories_tsv.rb
@@ -1,0 +1,19 @@
+class GeneCategoriesTsv
+  def self.table_headers
+    [
+      'gene',
+      'category',
+      'sources'
+    ]
+  end
+
+  def self.to_row(object: )
+    object.gene_categories_with_sources.map do |c|
+      [
+        object.name,
+        c.name,
+        c.source_names.join(',')
+      ]
+    end
+  end
+end

--- a/server/app/tsv_exporters/gene_interactions_tsv.rb
+++ b/server/app/tsv_exporters/gene_interactions_tsv.rb
@@ -1,0 +1,26 @@
+class GeneInteractionsTsv
+  def self.table_headers
+    [
+      'gene',
+      'drug',
+      'regulatory approval',
+      'indication',
+      'interaction score'
+    ]
+  end
+
+  def self.to_row(object: )
+    object.interactions.includes(drug: [:drug_attributes]).map do |i|
+      [
+        object.name,
+        i.drug.name,
+        i.drug.approved ? 'Approved' : 'Not Approved',
+        i.drug.drug_attributes
+          .select { |da| da.name == 'Drug Indications' }
+          .map(&:value)
+          .join(','),
+        i.interaction_score
+      ]
+    end
+  end
+end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   post "/api/graphql", to: "graphql#execute"
+  post "/api/graphql/download/:table_name", to: "table_download#download_table"
 
   mount GraphiQL::Rails::Engine, at: "/api/graphiql", graphql_path: "/api/graphql"
 end


### PR DESCRIPTION
This introduces a new API endpoint and corresponding React component that allows for a user to download a data TSV based on the current parameters used in a query.

I wanted to get feedback on the approach before hooking it up to every table. It also will require some visual polish, I'm not sure how to constrain the size of the MUI loading spinner or error banner, so the button increases in size when either is present. (And the `LoadingButton` appears to be in beta/not shipped with the default library)

The `<TableDownloader/>` component takes two props: `tableName` which is the name of the table you want to download. This is registered in the  `table_resolvers` dictionary in the table downloads controller server side.

This determines which `Resolver` will get used to generate the TSV. (Basically which top level query is this table using).

Then, the resolver in question will need to implement two methods: `table_headers` and `to_row(object:)`. This instructs the resolver how to build the individual TSV rows. For `genes` here I've implemented the same columns we show on the frontend, but this gives us the flexibility to do other things too. We could include columns like ids, or urls to the individual records that we may not want to show visually in the table.

The second prop on the `<TableDownloader>` is `vars` This is simply the same data structure you pass to the `gql` query used to generate the table in the first place. This ensures the TSV is scoped in the same way as the table as the same params will be passed into the resolver. In this examples, it's the gene names used in the initial search query.

Finally, because the TSV can be arbitrarily large, the entire thing is streamed to the client by the server rather than being built up in memory and sent as one large chunk.

Its not a huge change in terms of lines of code, but its pretty dense, so I'm happy to walk through it start to finish on a call!
