### PR TITLE
Add id to interaction hook

### DIFF
--- a/client/src/hooks/queries/useGetInteractions.ts
+++ b/client/src/hooks/queries/useGetInteractions.ts
@@ -10,6 +10,7 @@ const getInteractionsByGenesQuery = gql`
         name
         conceptId
         interactions {
+          id
           drug {
             name
             approved
@@ -48,6 +49,7 @@ const getInteractionsByDrugsQuery = gql`
     drugs(names: $names) {
       nodes {
         interactions {
+          id
           gene {
             name
             geneCategories {

--- a/server/spec/queries/drug_interaction_query_spec.rb
+++ b/server/spec/queries/drug_interaction_query_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Drug Interaction Query', type: :graphql do
       drugs(names: $names) {
         nodes {
           interactions {
+            id
             gene {
               name
               geneCategories {
@@ -66,6 +67,7 @@ RSpec.describe 'Drug Interaction Query', type: :graphql do
     expect(drug['name']).to eq @drug.name
     # expect(drug['approved']).to be true
 
+    expect(interaction['id']).to eq @int.id
     expect(interaction['interactionScore']).to eq @int.score
     expect(interaction['interactionTypes'].size).to eq 1
     expect(interaction['interactionTypes'][0]['type']).to eq @int_type.type

--- a/server/spec/queries/gene_interaction_query_spec.rb
+++ b/server/spec/queries/gene_interaction_query_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Gene Interaction Query', type: :graphql do
         nodes {
           name
           interactions {
+            id
             drug {
               name
               approved
@@ -76,6 +77,7 @@ RSpec.describe 'Gene Interaction Query', type: :graphql do
 
     expect(interaction['gene']['name']).to eq @gene.name
 
+    expect(interaction['id']).to eq @int.id
     expect(interaction['interactionScore']).to eq @int.score
     expect(interaction['interactionTypes'].size).to eq 1
     expect(interaction['interactionTypes'][0]['type']).to eq @int_type.type


### PR DESCRIPTION
interaction record page PR adds in routes to access interactions via: /interactions/<interaction_id>

This PR adds the <id> field to the hook used for drug and gene interactions (with tests added as well). I think theoretically this now will allow us to make interaction results clickable and directly link MUI TableRows to these records via that ID field (ala: https://stackoverflow.com/questions/50691049/how-to-add-link-react-router-per-each-material-ui-tablerow)

or I think you mentioned datagrid was being used, so potentially this: https://codesandbox.io/s/67252192react-material-ui-data-grid-add-link-z3izj?file=/demo.tsx 