### PR TITLE
Misc static info changes

### DIFF
--- a/client/src/components/Browse/Sources/BrowseSources.scss
+++ b/client/src/components/Browse/Sources/BrowseSources.scss
@@ -24,10 +24,10 @@
       border: 5px;
     }
     .source-versioning {
-      float: right;
-      // font-size: 0.6rem;
+      float: right bottom;
+      font-size: 1rem;
       font-weight: 350;
-      margin-left:0.75em;
+      // margin-left:0.75em;
       color: var(--text-accent)
     }
     .source-section {

--- a/client/src/components/Browse/Sources/BrowseSources.scss
+++ b/client/src/components/Browse/Sources/BrowseSources.scss
@@ -23,6 +23,13 @@
       padding: 10px;
       border: 5px;
     }
+    .source-versioning {
+      float: right;
+      // font-size: 0.6rem;
+      font-weight: 350;
+      margin-left:0.75em;
+      color: var(--text-accent)
+    }
     .source-section {
       background-color: white;
       margin: 10px;

--- a/client/src/components/Browse/Sources/BrowseSources.scss
+++ b/client/src/components/Browse/Sources/BrowseSources.scss
@@ -27,7 +27,6 @@
       float: right bottom;
       font-size: 1rem;
       font-weight: 350;
-      // margin-left:0.75em;
       color: var(--text-accent)
     }
     .source-section {

--- a/client/src/components/Browse/Sources/BrowseSources.tsx
+++ b/client/src/components/Browse/Sources/BrowseSources.tsx
@@ -68,10 +68,12 @@ export const BrowseSources = () => {
 
     const interactionClaimsCountExists = src.interactionClaimsCount ? true : false
     const interactionClaimsInGroupExists = src.interactionClaimsInGroupsCount ? true : false
-    
+
     return (
       <>
-        <Box className="source-item-name">{src.sourceDbName}</Box>
+        <Box className="source-item-name">{src.sourceDbName}
+          <Box className="source-versioning">text text text</Box>
+        </Box>
         <Box className="source-item-rows">
           <Box className="source-section" hidden={!(geneClaimsCountExists && geneClaimsInGroupExists)}>
             <Box><b>Gene Claims Count:</b> {src.geneClaimsCount}</Box>
@@ -117,7 +119,7 @@ export const BrowseSources = () => {
           {
             sectionsMap.map((section: any) => {
               return (
-                <Button variant={filter === section.value ? "outlined" : "contained"} 
+                <Button variant={filter === section.value ? "outlined" : "contained"}
                 value={section.value}
                 key={section.value}>
                   {section.value}
@@ -143,7 +145,7 @@ export const BrowseSources = () => {
               </Box>
             </Box>
           ) : <></>
-        }) 
+        })
       }
     </Box>
   )

--- a/client/src/components/Browse/Sources/BrowseSources.tsx
+++ b/client/src/components/Browse/Sources/BrowseSources.tsx
@@ -72,7 +72,7 @@ export const BrowseSources = () => {
     return (
       <>
         <Box className="source-item-name">{src.sourceDbName}
-          <Box className="source-versioning">text text text</Box>
+          <Box className="source-versioning">Version: {src.sourceDbVersion}</Box>
         </Box>
         <Box className="source-item-rows">
           <Box className="source-section" hidden={!(geneClaimsCountExists && geneClaimsInGroupExists)}>

--- a/client/src/components/Browse/Sources/BrowseSources.tsx
+++ b/client/src/components/Browse/Sources/BrowseSources.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-
+import { Link } from 'react-router-dom';
 // hooks/dependencies
 import {
   useGetDruggableSources,
@@ -71,7 +71,7 @@ export const BrowseSources = () => {
 
     return (
       <>
-        <Box className="source-item-name">{src.sourceDbName}
+        <Box className="source-item-name"><a href={src.baseUrl}>{src.sourceDbName}</a>
           <Box className="source-versioning">Version: {src.sourceDbVersion}</Box>
         </Box>
         <Box className="source-item-rows">

--- a/client/src/hooks/queries/useGetDruggableSources.ts
+++ b/client/src/hooks/queries/useGetDruggableSources.ts
@@ -14,6 +14,7 @@ query sources($sourceType: SourceTypeFilter) {
     nodes {
       sourceDbName
       sourceDbVersion
+      baseUrl
       categoriesInSource {
         name
         geneCount
@@ -59,6 +60,7 @@ query sources($sourceType: SourceTypeFilter) {
     nodes {
       sourceDbName
       sourceDbVersion
+      baseUrl
       geneClaimsCount
       geneClaimsInGroupsCount
       citation
@@ -96,6 +98,7 @@ query sources($sourceType: SourceTypeFilter) {
     nodes {
       sourceDbName
       sourceDbVersion
+      baseUrl
       drugClaimsCount
       drugClaimsInGroupsCount
       citation
@@ -133,6 +136,7 @@ query sources($sourceType: SourceTypeFilter) {
     nodes {
       sourceDbName
       sourceDbVersion
+      baseUrl
       drugClaimsCount
       drugClaimsInGroupsCount
       geneClaimsCount

--- a/client/src/hooks/queries/useGetDruggableSources.ts
+++ b/client/src/hooks/queries/useGetDruggableSources.ts
@@ -13,6 +13,7 @@ query sources($sourceType: SourceTypeFilter) {
     }
     nodes {
       sourceDbName
+      sourceDbVersion
       categoriesInSource {
         name
         geneCount
@@ -57,6 +58,7 @@ query sources($sourceType: SourceTypeFilter) {
     }
     nodes {
       sourceDbName
+      sourceDbVersion
       geneClaimsCount
       geneClaimsInGroupsCount
       citation
@@ -93,6 +95,7 @@ query sources($sourceType: SourceTypeFilter) {
     }
     nodes {
       sourceDbName
+      sourceDbVersion
       drugClaimsCount
       drugClaimsInGroupsCount
       citation
@@ -129,6 +132,7 @@ query sources($sourceType: SourceTypeFilter) {
     }
     nodes {
       sourceDbName
+      sourceDbVersion
       drugClaimsCount
       drugClaimsInGroupsCount
       geneClaimsCount

--- a/client/src/pages/Downloads/SubSections/Info.tsx
+++ b/client/src/pages/Downloads/SubSections/Info.tsx
@@ -3,7 +3,7 @@ export const Info = () => {
     return(
         <div className="about-section-container doc-section">
             <p>This page provides access to raw data for DGIdb. While the application is open source, some of the data sources we import may have restrictions that prevent us from redistributing them. Please refer to the Browse Sources page for license information for each source.</p>
-            <p>You may load the latest data dump into your local database instance by running the following command while in your local checkout of the DGIdb repository: rake dgidb:load_local . This will recreate your local database and import the latest data dump directly from the data repository. The data.sql file can then be found in the `data` directory of your local repository. Please see the Installation instructions for more details about creating a local instance of DGIdb.</p>
+            <p>You may load the latest data dump into your local database instance by running the following command while in your local checkout of the DGIdb repository: psql -d dgidb -f dgidb_v5_20230208_m1.sql. This will recreate your local database and import the <a href='https://nch-igm-wagner-lab-public.s3.us-east-2.amazonaws.com/dgidb_v5_20230208_m1.sql'>latest data dump</a> directly. Please see the Installation instructions for more details about creating a local instance of DGIdb.</p>
             <p>TSV download of all gene claims, drug claims, and drug-gene interaction claims in DGIdb from all sources that were mapped to valid genes. For ease of use, we recommend working directly with the API or SQL database dump.</p>
         </div>
 

--- a/server/spec/queries/sources_queries_spec.rb
+++ b/server/spec/queries/sources_queries_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Sources queries', type: :graphql do
         }
         nodes {
           sourceDbName
+          baseUrl
           drugClaimsCount
           drugClaimsInGroupsCount
           citation
@@ -46,6 +47,7 @@ RSpec.describe 'Sources queries', type: :graphql do
     expect(result['data']['sources']['nodes'].size).to eq 1
     source = result['data']['sources']['nodes'][0]
     expect(source['sourceDbName']).to eq @src.source_db_name
+    expect(source['baseUrl']).to eq @src.base_url
 
     expect(source['drugClaimsCount']).to eq 1
     expect(source['drugClaimsInGroupsCount']).to eq 1

--- a/server/spec/queries/sources_queries_spec.rb
+++ b/server/spec/queries/sources_queries_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Sources queries', type: :graphql do
         }
         nodes {
           sourceDbName
+          sourceDbVersion
           baseUrl
           drugClaimsCount
           drugClaimsInGroupsCount
@@ -47,6 +48,7 @@ RSpec.describe 'Sources queries', type: :graphql do
     expect(result['data']['sources']['nodes'].size).to eq 1
     source = result['data']['sources']['nodes'][0]
     expect(source['sourceDbName']).to eq @src.source_db_name
+    expect(source['sourceDbVersion']).to eq @src.source_db_version
     expect(source['baseUrl']).to eq @src.base_url
 
     expect(source['drugClaimsCount']).to eq 1


### PR DESCRIPTION
closes #309 

This PR makes a couple of small miscellaneous changes for the information pages:

- sources versioning: versioning has been added per source (tests updated to match)
- hyperlink sources: source headers now hyperlink out to their respective sites (tests updated to match)
- downloads: instructions for loading the v5 database have been updated, as well as a link to sql data dump


