### PR TITLE
More example queries

### DIFF
--- a/client/src/pages/Playground/Playground.tsx
+++ b/client/src/pages/Playground/Playground.tsx
@@ -10,6 +10,7 @@ import { createGraphiQLFetcher } from '@graphiql/toolkit'
 // styles
 import { Button, Collapse } from 'antd';
 import 'graphiql/graphiql.min.css';
+import { purple } from '@mui/material/colors';
 
 const CopyToClipboard = require('react-copy-to-clipboard')
 
@@ -20,7 +21,8 @@ const buttonStyle = {
   border: 'none'
 };
 const defaultStyle = {
-  backgroundColor: 'var(--background-light)'
+  // backgroundColor: 'var(--background-light)'
+  backgroundColor: '#f3e5f5'
 }
 
 // queries

--- a/client/src/pages/Playground/Playground.tsx
+++ b/client/src/pages/Playground/Playground.tsx
@@ -131,6 +131,29 @@ const query4 = `
   }
 }
 `
+
+const query5 = `
+{
+  drugs(first:50 after:"NTE") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+    pageCount
+    edges {
+      cursor
+      node {
+        name
+        conceptId
+        approved
+      }
+    }
+  }
+}
+`
+
 const fetcher = createGraphiQLFetcher({ url: API_URL ?? ''})
 
 export const Playground = () => {
@@ -182,6 +205,18 @@ export const Playground = () => {
             </CopyToClipboard>
             <pre><code>{query4}</code></pre>
           </Panel>
+
+          <Panel header="Pagination Example (all Drugs)" key="5" style={defaultStyle}>
+          An example of cursor-based approach to paginating through all available drug records in DGIdb (in increments of 100 records).<br/><br/>
+          Use cursor location to paginate through an additional records.<br/><br/>
+            <CopyToClipboard text={query5} onCopy={onCopyText}>
+              <span>{isCopied ? <Button style={buttonStyle}>Copied!</Button>
+                              : <Button style={buttonStyle}>Copy Query to Clipboard</Button>}</span>
+            </CopyToClipboard>
+            <pre><code>{query5}</code></pre>
+          </Panel>
+
+
 
         </Collapse>
       </div>

--- a/client/src/pages/Playground/Playground.tsx
+++ b/client/src/pages/Playground/Playground.tsx
@@ -10,7 +10,6 @@ import { createGraphiQLFetcher } from '@graphiql/toolkit'
 // styles
 import { Button, Collapse } from 'antd';
 import 'graphiql/graphiql.min.css';
-import { purple } from '@mui/material/colors';
 
 const CopyToClipboard = require('react-copy-to-clipboard')
 
@@ -21,7 +20,6 @@ const buttonStyle = {
   border: 'none'
 };
 const defaultStyle = {
-  // backgroundColor: 'var(--background-light)'
   backgroundColor: '#f3e5f5'
 }
 

--- a/client/src/pages/Playground/Playground.tsx
+++ b/client/src/pages/Playground/Playground.tsx
@@ -134,7 +134,7 @@ const query4 = `
 
 const query5 = `
 {
-  drugs(first:50 after:"NTE") {
+  drugs(first:100 after:"NTA") {
     pageInfo {
       startCursor
       endCursor
@@ -148,6 +148,31 @@ const query5 = `
         name
         conceptId
         approved
+      }
+    }
+  }
+}
+`
+
+const query6 = `
+{
+  genes(first:100 after:"NTA") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+    pageCount
+    edges {
+      cursor
+      node {
+        name
+        conceptId
+        longName
+        geneCategories {
+          name
+        }
       }
     }
   }
@@ -208,7 +233,7 @@ export const Playground = () => {
 
           <Panel header="Pagination Example (all Drugs)" key="5" style={defaultStyle}>
           An example of cursor-based approach to paginating through all available drug records in DGIdb (in increments of 100 records).<br/><br/>
-          Use cursor location to paginate through an additional records.<br/><br/>
+          Use cursor location in conjunction with <i>before</i> and <i>after</i> keywords to paginate through additional records.<br/><br/>
             <CopyToClipboard text={query5} onCopy={onCopyText}>
               <span>{isCopied ? <Button style={buttonStyle}>Copied!</Button>
                               : <Button style={buttonStyle}>Copy Query to Clipboard</Button>}</span>
@@ -216,6 +241,15 @@ export const Playground = () => {
             <pre><code>{query5}</code></pre>
           </Panel>
 
+          <Panel header="Pagination Example (all Genes)" key="6" style={defaultStyle}>
+          An example of cursor-based approach to paginating through all available gene records in DGIdb (in increments of 100 records).<br/><br/>
+          Use cursor location in conjunction with <i>before</i> and <i>after</i> keywords to paginate through additional records.<br/><br/>
+            <CopyToClipboard text={query6} onCopy={onCopyText}>
+              <span>{isCopied ? <Button style={buttonStyle}>Copied!</Button>
+                              : <Button style={buttonStyle}>Copy Query to Clipboard</Button>}</span>
+            </CopyToClipboard>
+            <pre><code>{query6}</code></pre>
+          </Panel>
 
 
         </Collapse>


### PR DESCRIPTION
this PR adds example queries for pagination in graphql using the drugs and gene endpoints. Highlights the use of before and after with cursors to paginate.

(am also open to better/additional examples of pagination if this method doesn't work)