### PR TITLE
fix: Resolvers distinct fix

### DIFF
--- a/server/app/graphql/resolvers/drugs.rb
+++ b/server/app/graphql/resolvers/drugs.rb
@@ -7,7 +7,7 @@ class Resolvers::Drugs < GraphQL::Schema::Resolver
 
   type Types::DrugType.connection_type, null: false
 
-  scope { Drug.all }
+  scope { Drug.all.distinct }
 
   option(:ids, type: [String], description: 'Exact match filtering on a list of drug IDs') do |scope, value|
     scope.where(id: value)

--- a/server/app/graphql/resolvers/genes.rb
+++ b/server/app/graphql/resolvers/genes.rb
@@ -6,7 +6,7 @@ class Resolvers::Genes < GraphQL::Schema::Resolver
 
   type Types::GeneType.connection_type, null: false
 
-  scope { Gene.all }
+  scope { Gene.all.distinct }
 
   option(:ids, type: [String]) { |scope, value| scope.where(id: value)}
   option(:names, type: [String]) { |scope, value| scope.where(name: value.map(&:upcase)) }


### PR DESCRIPTION
This PR resolves an issue found regarding resolvers joining redundant rows when filters are utilized.

Example case:
```
{
  genes(names: ["BCL2","ABL1","PDGFRA"]) {
    nodes {
      name
      interactions {
        drug {
          name
          conceptId
        }
        interactionScore
        interactionTypes {
          type
          directionality
        }
        interactionAttributes {
          name
          value
        }
        publications {
          pmid
        }
        sources {
          sourceDbName
        }
      }
    }
  }
}
```
returns 212 results

```
{
  genes(names: ["BCL2","ABL1","PDGFRA"], sourceDbName: "NCI") {
    nodes {
      name
      interactions {
        drug {
          name
          conceptId
        }
        interactionScore
        interactionTypes {
          type
          directionality
        }
        interactionAttributes {
          name
          value
        }
        publications {
          pmid
        }
        sources {
          sourceDbName
        }
      }
    }
  }
}
```
returns 4962 results