### PR TITLE
fix: use buckets for approval rating graphic

### DIFF
--- a/client/src/components/Gene/GeneCharts/RegulatoryApprovalGene.tsx
+++ b/client/src/components/Gene/GeneCharts/RegulatoryApprovalGene.tsx
@@ -28,18 +28,16 @@ export const RegulatoryApprovalGene: React.FC<Props> = ({data}) => {
   useEffect(() => {
     let newObj: ApprovalRatings = {};
 
-      data?.forEach((gene: any) => {
-        gene.interactions?.forEach((int: any) => {
-          int?.drug?.drugApprovalRatings?.forEach((rating: any) => {
-            if (newObj[rating.rating]) {
-              ++newObj[rating.rating];
-            } else {
-              newObj[rating.rating] = 1;
-            }
-          })
-        })
+    data?.forEach((gene: any) => {
+      gene.interactions?.forEach((int: any) => {
+        const rating = int?.drug?.approved ? "Approved" : "Not Approved";
+        if (newObj[rating]) {
+          ++newObj[rating];
+        } else {
+          newObj[rating] = 1;
+        }
       })
-
+    })
     let dataArray = [];
     let labelArray = []
 

--- a/server/lib/genome/importers/file_importers/chembl.rb
+++ b/server/lib/genome/importers/file_importers/chembl.rb
@@ -85,7 +85,7 @@ module Genome; module Importers; module FileImporters; module Chembl
         primary_drug_name = row['drug_name'].strip.upcase
         drug_claim = create_drug_claim(primary_drug_name)
         create_drug_claim_alias(drug_claim, "chembl:#{row['chembl_id']}", DrugNomenclature::CHEMBL_ID)
-        create_drug_claim_approval_rating(drug_claim, "Max Phase #{row['max_phase']}") unless row[5].nil?
+        create_drug_claim_approval_rating(drug_claim, "Max Phase #{row['max_phase'].strip}") unless row[5].nil?
         create_drug_claim_approval_rating(drug_claim, 'Withdrawn') if row[3] == 1
 
         next if row['chembl_id'].nil? || row['target_gene_symbol'].nil?


### PR DESCRIPTION
close #338 

Generally I think we probably have to use the same normalized values that show up in the results table -- otherwise it's a little confusing. It'd be great to put some thought into a combined approval rating strategy though (card in the drug results page/more ideas for how to display a summary in the interaction tables)

![Screenshot 2023-05-31 at 1 09 56 PM](https://github.com/dgidb/dgidb-v5/assets/12942397/977d589c-17da-40c3-96a7-c262284b51d8)
