### PR TITLE
feat: provide hyperlinks to resources from xrefs

### DIFF
--- a/client/src/components/Drug/DrugRecord/DrugRecord.scss
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.scss
@@ -25,6 +25,19 @@
       margin-left: 0.75em;
       margin-bottom: 0.22em;
     }
+
+    .concept-id-link {
+      color: var(--text-accent) !important;
+      text-decoration: none !important;
+    }
+
+    .concept-id-link:hover {
+      text-decoration: underline !important;
+    }
+
+    .concept-id-link:active {
+      text-decoration: underline !important;
+    }
   }
 
   .data-box {

--- a/client/src/components/Drug/DrugRecord/DrugRecord.tsx
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.tsx
@@ -20,6 +20,8 @@ import Table from '@mui/material/Table';
 import { LinearProgress, Link } from '@mui/material';
 import InteractionTable from 'components/Shared/InteractionTable/InteractionTable';
 import { useGetDrugInteractions } from 'hooks/queries/useGetDrugInteractions';
+import { generateXrefLink } from 'utils/generateXrefLink';
+import { ResultTypes } from 'types/types';
 
 export const DrugRecord: React.FC = () => {
   const drugId = useParams().drug as string;
@@ -96,7 +98,7 @@ export const DrugRecord: React.FC = () => {
                   return (
                     <TableRow key={alias.alias}>
                       <TableCell className="attribute-name">
-                        {alias.alias}
+                        {generateXrefLink(alias.alias, ResultTypes.Drug, 'meta-link')}
                       </TableCell>
                     </TableRow>
                   );
@@ -204,7 +206,7 @@ export const DrugRecord: React.FC = () => {
     <Box className="drug-record-container">
       <Box className="drug-record-header">
         <Box className="name">{drugData?.name}</Box>
-        <Box className="concept-id">{drugId}</Box>
+        <Box className="concept-id">{generateXrefLink(drugId, ResultTypes.Drug, 'concept-id-link')}</Box>
       </Box>
       <Box display="flex">
         <Box display="block" width="35%">

--- a/client/src/components/Drug/DrugRecord/DrugRecord.tsx
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.tsx
@@ -98,7 +98,11 @@ export const DrugRecord: React.FC = () => {
                   return (
                     <TableRow key={alias.alias}>
                       <TableCell className="attribute-name">
-                        {generateXrefLink(alias.alias, ResultTypes.Drug, 'meta-link')}
+                        {generateXrefLink(
+                          alias.alias,
+                          ResultTypes.Drug,
+                          'meta-link'
+                        )}
                       </TableCell>
                     </TableRow>
                   );
@@ -206,7 +210,9 @@ export const DrugRecord: React.FC = () => {
     <Box className="drug-record-container">
       <Box className="drug-record-header">
         <Box className="name">{drugData?.name}</Box>
-        <Box className="concept-id">{generateXrefLink(drugId, ResultTypes.Drug, 'concept-id-link')}</Box>
+        <Box className="concept-id">
+          {generateXrefLink(drugId, ResultTypes.Drug, 'concept-id-link')}
+        </Box>
       </Box>
       <Box display="flex">
         <Box display="block" width="35%">

--- a/client/src/components/Gene/GeneRecord/GeneRecord.scss
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.scss
@@ -25,6 +25,19 @@
       margin-left: 0.75em;
       margin-bottom: 0.22em;
     }
+
+    .concept-id-link {
+      color: var(--text-accent) !important;
+      text-decoration: none !important;
+    }
+
+    .concept-id-link:hover {
+      text-decoration: underline !important;
+    }
+
+    .concept-id-link:active {
+      text-decoration: underline !important;
+    }
   }
 
   .data-box {
@@ -106,15 +119,15 @@
   }
 }
 
-.pub-link {
+.meta-link {
   color: var(--header-gradient-1) !important;
   text-decoration: none !important;
 }
 
-.pub-link:hover {
+.meta-link:hover {
   text-decoration: underline !important;
 }
 
-.pub-link:active {
+.meta-link:active {
   text-decoration: underline !important;
 }

--- a/client/src/components/Gene/GeneRecord/GeneRecord.tsx
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.tsx
@@ -19,6 +19,8 @@ import { LinearProgress, Link } from '@mui/material';
 import { useGetGeneInteractions } from 'hooks/queries/useGetGeneInteractions';
 import InteractionTable from 'components/Shared/InteractionTable/InteractionTable';
 import { dropRedundantCites } from 'utils/dropRedundantCites';
+import { generateXrefLink } from 'utils/generateXrefLink';
+import { ResultTypes } from 'types/types';
 
 export const GeneRecord: React.FC = () => {
   const geneId: any = useParams().gene;
@@ -101,7 +103,7 @@ export const GeneRecord: React.FC = () => {
                   return (
                     <TableRow key={alias.alias}>
                       <TableCell className="attribute-name">
-                        {alias.alias}
+                        {generateXrefLink(alias.alias, ResultTypes.Gene, 'meta-link')}
                       </TableCell>
                     </TableRow>
                   );
@@ -169,7 +171,7 @@ export const GeneRecord: React.FC = () => {
                   <TableRow key={index}>
                     <TableCell className="attribute-name">
                       <Link
-                        className="pub-link"
+                        className="meta-link"
                         href={'https://pubmed.ncbi.nlm.nih.gov/' + pub.pmid}
                         target="_blank"
                       >
@@ -202,7 +204,7 @@ export const GeneRecord: React.FC = () => {
     <Box className="content gene-record-container">
       <Box className="gene-record-header">
         <Box className="symbol">{geneData?.name}</Box>
-        <Box className="concept-id">{geneId}</Box>
+        <Box className="concept-id">{generateXrefLink(geneId, ResultTypes.Gene, 'concept-id-link')}</Box>
       </Box>
       <Box display="flex">
         <Box display="block" width="35%">

--- a/client/src/components/Gene/GeneRecord/GeneRecord.tsx
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.tsx
@@ -103,7 +103,11 @@ export const GeneRecord: React.FC = () => {
                   return (
                     <TableRow key={alias.alias}>
                       <TableCell className="attribute-name">
-                        {generateXrefLink(alias.alias, ResultTypes.Gene, 'meta-link')}
+                        {generateXrefLink(
+                          alias.alias,
+                          ResultTypes.Gene,
+                          'meta-link'
+                        )}
                       </TableCell>
                     </TableRow>
                   );
@@ -204,7 +208,9 @@ export const GeneRecord: React.FC = () => {
     <Box className="content gene-record-container">
       <Box className="gene-record-header">
         <Box className="symbol">{geneData?.name}</Box>
-        <Box className="concept-id">{generateXrefLink(geneId, ResultTypes.Gene, 'concept-id-link')}</Box>
+        <Box className="concept-id">
+          {generateXrefLink(geneId, ResultTypes.Gene, 'concept-id-link')}
+        </Box>
       </Box>
       <Box display="flex">
         <Box display="block" width="35%">

--- a/client/src/utils/generateXrefLink.tsx
+++ b/client/src/utils/generateXrefLink.tsx
@@ -4,18 +4,33 @@ import { ResultTypes } from 'types/types';
 const drugPatterns: [RegExp, string][] = [
   [/^PUBCHEM.COMPOUND:(.+)/, 'https://pubchem.ncbi.nlm.nih.gov/compound/'],
   [/^CHEMBL:(.+)/i, 'https://www.ebi.ac.uk/chembl/compound_report_card/'],
-  [/^NCIT:(.+)/i, 'https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&ns=ncit&code='],
+  [
+    /^NCIT:(.+)/i,
+    'https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&ns=ncit&code=',
+  ],
   [/^DRUGBANK:(.+)/i, 'https://go.drugbank.com/drugs/'],
   [/^WIKIDATA:(.+)/i, 'https://www.wikidata.org/wiki/'],
   [/^CHEMIDPLUS:(.+)/i, 'https://pubchem.ncbi.nlm.nih.gov/#query='],
-  [/^IUPHAR.LIGAND:(.+)/i, 'https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId='],
-  [/^RXCUI:(.+)/i, 'https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm='],
+  [
+    /^IUPHAR.LIGAND:(.+)/i,
+    'https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=',
+  ],
+  [
+    /^RXCUI:(.+)/i,
+    'https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=',
+  ],
 ];
 
 const genePatterns: [RegExp, string][] = [
   [/^NCBIGENE:(.+)/i, 'https://www.ncbi.nlm.nih.gov/gene/?term='],
-  [/^ENSEMBL:(.+)/i, 'https://ensembl.org/Homo_sapiens/Gene/Summary?db=core;g='],
-  [/^HGNC:(.+)/i, 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:'],
+  [
+    /^ENSEMBL:(.+)/i,
+    'https://ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=',
+  ],
+  [
+    /^HGNC:(.+)/i,
+    'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:',
+  ],
   [/^UCSC:(.+)/, 'https://genome.cse.ucsc.edu/cgi-bin/hgGene?hgg_gene='],
   [
     /^CCDS:(.+)/,
@@ -36,10 +51,17 @@ const genePatterns: [RegExp, string][] = [
   [/^ENA\.EMBL:(.+)/, 'https://www.ebi.ac.uk/ena/browser/view/'],
   [/^CIVIC\.GID:(.+)/, 'https://civicdb.org/genes/'],
   [/^CHEMBL:(.+)/, 'https://www.ebi.ac.uk/chembl/target_report_card/'],
-  [/^IUPHAR\.RECEPTOR:(.+)/, 'https://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId='],
+  [
+    /^IUPHAR\.RECEPTOR:(.+)/,
+    'https://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId=',
+  ],
 ];
 
-export const generateXrefLink = (xref: string, itemType: ResultTypes, linkClassName: string = '') => {
+export const generateXrefLink = (
+  xref: string,
+  itemType: ResultTypes,
+  linkClassName: string = ''
+) => {
   if (!xref.includes(':')) {
     return <>{xref}</>;
   }

--- a/client/src/utils/generateXrefLink.tsx
+++ b/client/src/utils/generateXrefLink.tsx
@@ -1,0 +1,68 @@
+import { Link } from '@mui/material';
+import { ResultTypes } from 'types/types';
+
+const drugPatterns: [RegExp, string][] = [
+  [/^PUBCHEM.COMPOUND:(.+)/, 'https://pubchem.ncbi.nlm.nih.gov/compound/'],
+  [/^CHEMBL:(.+)/i, 'https://www.ebi.ac.uk/chembl/compound_report_card/'],
+  [/^NCIT:(.+)/i, 'https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&ns=ncit&code='],
+  [/^DRUGBANK:(.+)/i, 'https://go.drugbank.com/drugs/'],
+  [/^WIKIDATA:(.+)/i, 'https://www.wikidata.org/wiki/'],
+  [/^CHEMIDPLUS:(.+)/i, 'https://pubchem.ncbi.nlm.nih.gov/#query='],
+  [/^IUPHAR.LIGAND:(.+)/i, 'https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId='],
+  [/^RXCUI:(.+)/i, 'https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm='],
+];
+
+const genePatterns: [RegExp, string][] = [
+  [/^NCBIGENE:(.+)/i, 'https://www.ncbi.nlm.nih.gov/gene/?term='],
+  [/^ENSEMBL:(.+)/i, 'https://ensembl.org/Homo_sapiens/Gene/Summary?db=core;g='],
+  [/^HGNC:(.+)/i, 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:'],
+  [/^UCSC:(.+)/, 'https://genome.cse.ucsc.edu/cgi-bin/hgGene?hgg_gene='],
+  [
+    /^CCDS:(.+)/,
+    'https://www.ncbi.nlm.nih.gov/projects/CCDS/CcdsBrowse.cgi?REQUEST=ALLFIELDS&ORGANISM=0&BUILDS=CURRENTBUILDS&DATA=',
+  ],
+  [/^COSMIC:(.+)/, 'https://cancer.sanger.ac.uk/cosmic/gene/analysis?ln='],
+  [
+    /^ORPHANET:(.+)/,
+    'https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=',
+  ],
+  [/^UNIPROT:(.+)/, 'https://www.uniprot.org/uniprotkb/'],
+  [/^OMIM:(.+)/, 'https://www.omim.org/entry/'],
+  [/^REFSEQ:(.+)/, 'https://www.ncbi.nlm.nih.gov/nuccore/'],
+  [
+    /^VEGA:(.+)/,
+    'vega.archive.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g=',
+  ],
+  [/^ENA\.EMBL:(.+)/, 'https://www.ebi.ac.uk/ena/browser/view/'],
+  [/^CIVIC\.GID:(.+)/, 'https://civicdb.org/genes/'],
+  [/^CHEMBL:(.+)/, 'https://www.ebi.ac.uk/chembl/target_report_card/'],
+  [/^IUPHAR\.RECEPTOR:(.+)/, 'https://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId='],
+];
+
+export const generateXrefLink = (xref: string, itemType: ResultTypes, linkClassName: string = '') => {
+  if (!xref.includes(':')) {
+    return <>{xref}</>;
+  }
+  let url = '';
+  let patterns: [RegExp, string][] | null;
+  if (itemType === ResultTypes.Gene) {
+    patterns = genePatterns;
+  } else {
+    patterns = drugPatterns;
+  }
+  patterns.forEach(([pattern, url_base]: [RegExp, string]) => {
+    const match = xref.match(pattern);
+    if (match) {
+      url = url_base + match[1];
+    }
+  });
+  if (url.length === 0) {
+    return <>{xref}</>;
+  } else {
+    return (
+      <Link href={url} className={linkClassName} target="_blank">
+        {xref}
+      </Link>
+    );
+  }
+};


### PR DESCRIPTION
![Screenshot 2023-06-02 at 12 23 24 PM](https://github.com/dgidb/dgidb-v5/assets/12942397/8eb1c976-3bbb-43f8-93ef-65eda0fef99b)
If an alias looks like a URI, try to generate a hyperlink out to the source page if it matches patterns for known resources.

It'd be great to restrict this behavior to a separate xrefs box on the drug/gene pages, but I think this is a good start