### PR TITLE
fix: use symbol for CIViC gene claim name

### DIFF
--- a/server/lib/genome/importers/api_importers/civic/importer.rb
+++ b/server/lib/genome/importers/api_importers/civic/importer.rb
@@ -53,9 +53,9 @@ module Genome
           end
 
           def create_gene_claim_entries(gene)
-            gc = create_gene_claim(gene.official_name)
-            base_aliases = gene.gene_aliases + [gene.name]
-            base_aliases.uniq.reject { |n| n == gene.official_name }.each do |gene_alias|
+            gc = create_gene_claim(gene.name)
+            base_aliases = gene.gene_aliases + [gene.official_name]
+            base_aliases.uniq.reject { |n| n == gene.name }.each do |gene_alias|
               create_gene_claim_alias(gc, gene_alias, GeneNomenclature::SYMBOL)
             end
             create_gene_claim_alias(gc, "ncbigene:#{gene.entrez_id}", GeneNomenclature::NCBI_ID)


### PR DESCRIPTION
Tiny fix, but with reason:

* in v4, we used gene symbols for gene claim names from CIViC. I think we switched for v5 because the CIViC API refers to the full name as `officialName`, and that sounds very official. But the Gene Normalizer can't currently search full names (we should probably fix this?), and anyway, we typically try to use the symbol for the claim name in all other sources.
* Incidentally, this would also fix our KRAS/NRAS problem. 