### PR TITLE
fix: make home downloads link work

### DIFF
--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -34,14 +34,6 @@
         overflow: scroll !important;
         position: relative;
 
-        .ant-select-selection-item {
-          color: var(--theme-primary);
-        }
-
-        .ant-select-dropdown {
-          width: 50px;
-        }
-
         .search-filters {
           padding: 8px 6px 0 5px;
           cursor: pointer;
@@ -64,6 +56,7 @@
     font-size: 20px;
     margin-top: 10px;
   }
+
   .home-footer {
     background-color: var(--theme-primary);
     margin-top: auto;
@@ -81,17 +74,7 @@
     position: absolute;
     bottom: 15%;
     margin-right: 5%;
-
-    .ant-switch {
-      background-color: var(--theme-primary) !important;
-      color: var(--text-content);
-    }
   }
-}
-
-.ant-switch-inner .ionicon {
-  margin-top: 3.5px;
-  height: 15px;
 }
 
 .logo {
@@ -106,18 +89,6 @@
   );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
-}
-
-.ant-btn .ant-btn-link {
-  text-decoration: underline !important;
-}
-
-.ant-menu-submenu-popup {
-  left: 1080px !important;
-}
-
-.ant-menu-sub {
-  background-color: var(--background-light) !important;
 }
 
 a {

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -10,6 +10,8 @@ import { ActionTypes } from 'stores/Global/reducers';
 // import SunIcon from 'components/Shared/SVG/SunIcon';
 // import MoonIcon from 'components/Shared/SVG/MoonIcon';
 import './Home.scss';
+import { Box, Grid } from '@mui/material';
+import { Link } from 'react-router-dom';
 
 export const Home: React.FC = () => {
   const { state, dispatch } = useContext(GlobalClientContext);
@@ -47,76 +49,31 @@ export const Home: React.FC = () => {
     dispatch({ type: ActionTypes.BrandPage });
   }, []);
 
-  const handleDemoClick = () => {
-    switch (state.interactionMode) {
-      case 'gene':
-        dispatch({ type: ActionTypes.AddGeneDemoTerms });
-        break;
-      case 'drug':
-        dispatch({ type: ActionTypes.AddDrugDemoTerms });
-        break;
-      case 'categories':
-        dispatch({ type: ActionTypes.AddCategoryDemoTerms });
-        break;
-      default:
-        return;
-    }
-  };
-
   return (
     <div className="home-page-container">
-      {/* <div className="logo">
-        DGIdb
-      </div>
-      <div className="tagline">
-        THE DRUG GENE INTERACTION DATABASE
-      </div> */}
-
       <SearchBar handleSubmit={handleSubmit} />
       <div className="home-blurb">
         An open-source search engine for drug-gene interactions and the
         druggable genome.
       </div>
-      <div className="home-links">
-        <span
-          style={{
-            padding: '0 15px',
-            fontSize: 18,
-            textDecoration: 'underline',
-          }}
-        >
-          <a href="/api">API</a>
-        </span>
-        <span
-          style={{
-            padding: '0 15px',
-            fontSize: 18,
-            textDecoration: 'underline',
-          }}
-        >
-          <a href="/downloads">Downloads</a>
-        </span>
-        <span
-          style={{
-            padding: '0 15px',
-            fontSize: 18,
-            textDecoration: 'underline',
-          }}
-        >
-          <a href="https://github.com/dgidb/dgidb-v5">Github</a>
-        </span>
-      </div>
-
-      {/* todo: introduce at a later date
-      <div className="darkmode-toggle">
-        <Switch
-          loading={isToggling}
-          defaultChecked
-          checkedChildren={<SunIcon />}
-          unCheckedChildren={<MoonIcon />}
-          onChange={() => setIsToggling(true)}
-        />
-      </div> */}
+      <Box className="home-links">
+        <Grid container width="300px" justifyContent="space-between">
+          <Link className="home-link" to="/api">
+            API
+          </Link>
+          <Link className="home-link" to="/downloads">
+            Downloads
+          </Link>
+          <a
+            className="home-link"
+            href="https://github.com/dgidb/dgidb-v5"
+            rel="noreferrer"
+            target="_blank"
+          >
+            GitHub
+          </a>
+        </Grid>
+      </Box>
     </div>
   );
 };


### PR DESCRIPTION
Malachi noted on Slack that the downloads link on the homepage isn't working. Adam reports that it seems like it's trying to load a static HTML page from the server instead of hitting react-router. I don't know if this is going to work, but I'm hoping that calling the react router Link component instead of a good old `<a href>` will fix this.