### PR TITLE
fix: correct source versioning

### DIFF
--- a/server/lib/genome/importers/file_importers/caris_molecular_intelligence.rb
+++ b/server/lib/genome/importers/file_importers/caris_molecular_intelligence.rb
@@ -18,7 +18,7 @@ module Genome; module Importers; module FileImporters; module CarisMolecularInte
         {
           base_url: 'https://www.carislifesciences.com/molecular-profiling-technology/',
           site_url: 'http://www.carismolecularintelligence.com/',
-          source_db_version: set_current_date_version,
+          source_db_version: '2020-09-04',  # using static file
           source_db_name: source_db_name,
           full_name: 'Caris Molecular Intelligence',
           source_trust_level_id: SourceTrustLevel.EXPERT_CURATED,

--- a/server/lib/genome/importers/file_importers/cgi.rb
+++ b/server/lib/genome/importers/file_importers/cgi.rb
@@ -23,7 +23,7 @@ module Genome; module Importers; module FileImporters; module Cgi
           pmid: '29592813',
           pmcid: 'PMC5875005',
           doi: '10.1186/s13073-018-0531-8',
-          source_db_version: set_current_date_version,
+          source_db_version: '2022-02-01',  # using static file
           source_db_name: source_db_name,
           full_name: 'Cancer Genome Interpreter',
           license: License::CC_BY_NC_4_0,

--- a/server/lib/genome/importers/file_importers/dtc.rb
+++ b/server/lib/genome/importers/file_importers/dtc.rb
@@ -27,7 +27,7 @@ module Genome; module Importers; module FileImporters; module Dtc;
           pmid: '30219839',
           pmcid: 'PMC6146131',
           doi: '10.1093/database/bay083',
-          source_db_version: set_current_date_version,
+          source_db_version: '2020-09-02',  # using static file
           source_db_name: source_db_name,
           full_name: 'Drug Target Commons',
           license: License::CC_BY_NC_SA_3_0,

--- a/server/lib/genome/importers/file_importers/foundation_one_genes.rb
+++ b/server/lib/genome/importers/file_importers/foundation_one_genes.rb
@@ -23,7 +23,7 @@ module Genome; module Importers; module FileImporters; module FoundationOneGenes
           pmid: '22585170',
           pmcid: 'PMC3353152',
           doi: '10.1158/2159-8290.CD-11-0184',
-          source_db_version: set_current_date_version,
+          source_db_version: '2020-09-03',  # using static file
           source_trust_level_id: SourceTrustLevel.EXPERT_CURATED,
           source_db_name: source_db_name,
           full_name: 'Foundation One',

--- a/server/lib/genome/importers/file_importers/pharmgkb.rb
+++ b/server/lib/genome/importers/file_importers/pharmgkb.rb
@@ -23,7 +23,7 @@ module Genome; module Importers; module FileImporters; module Pharmgkb;
           pmid: '34216021',
           pmcid: 'PMC8457105',
           doi: '10.1002/cpt.2350',
-          source_db_version: set_current_date_version,
+          source_db_version: '2020-08-18',  # using static file, see issue #420
           source_db_name: source_db_name,
           full_name: 'PharmGKB - The Pharmacogenomics Knowledgebase',
           license: License::CC_BY_SA_4_0,


### PR DESCRIPTION
We were using the current date to set the version for a number of sources that are actually static imports (I think this was my bad). I went back and grabbed the date set in dgidb v4.