### PR TITLE
Update dgidb:load_local method

### DIFF
--- a/client/src/pages/Downloads/Info/Info.tsx
+++ b/client/src/pages/Downloads/Info/Info.tsx
@@ -18,21 +18,6 @@ export const Info = () => {
         <code className="code-text">rake dgidb:load_local</code>
       </Box>
       <p>
-        Alternatively, you may download the {' '}
-        <Link
-          href="https://nch-igm-wagner-lab-public.s3.us-east-2.amazonaws.com/dgidb_v5_latest.sql"
-          target="_blank"
-          rel="noopener"
-        >
-          latest data dump
-        </Link>{' '}
-        directly and run the following command
-        while in the directory of your local checkout of the DGIdb repository:
-      </p>
-      <Box sx={{ ml: 2 }} className="code-text-container">
-        <code className="code-text">psql -d dgidb -f dgidb_v5_latest.sql</code>
-      </Box>
-      <p>
         This will recreate the local database and import the latest data dump
         directly. Please see the{' '}
         <Link

--- a/client/src/pages/Downloads/Info/Info.tsx
+++ b/client/src/pages/Downloads/Info/Info.tsx
@@ -11,7 +11,14 @@ export const Info = () => {
         information for each source.
       </p>
       <p>
-        You may load the{' '}
+        You may instantiate your local database instance by running the following command while
+        in the 'server' directory of your local checkout of the DGIdb repository:
+      </p>
+      <Box sx={{ ml: 2 }} className="code-text-container">
+        <code className="code-text">rake dgidb:load_local</code>
+      </Box>
+      <p>
+        Alternatively, you may download the {' '}
         <Link
           href="https://nch-igm-wagner-lab-public.s3.us-east-2.amazonaws.com/dgidb_v5_latest.sql"
           target="_blank"
@@ -19,8 +26,8 @@ export const Info = () => {
         >
           latest data dump
         </Link>{' '}
-        into your local database instance by running the following command while
-        in your local checkout of the DGIdb repository:
+        directly and run the following command
+        while in the directory of your local checkout of the DGIdb repository:
       </p>
       <Box sx={{ ml: 2 }} className="code-text-container">
         <code className="code-text">psql -d dgidb -f dgidb_v5_latest.sql</code>

--- a/client/src/pages/Downloads/Info/Info.tsx
+++ b/client/src/pages/Downloads/Info/Info.tsx
@@ -11,15 +11,16 @@ export const Info = () => {
         information for each source.
       </p>
       <p>
-        You may instantiate your local database instance by running the following command while
-        in the 'server' directory of your local checkout of the DGIdb repository:
+        You may instantiate your local database instance by running the
+        following command while in the 'server' directory of your local checkout
+        of the DGIdb repository:
       </p>
       <Box sx={{ ml: 2 }} className="code-text-container">
         <code className="code-text">rake dgidb:load_local</code>
       </Box>
       <p>
         This will recreate the local database and import the latest data dump
-        directly. Please see the {' '}
+        directly. Please see the{' '}
         <Link
           href="https://github.com/dgidb/dgidb-v5/blob/main/README.md"
           target="_blank"

--- a/client/src/pages/Downloads/Info/Info.tsx
+++ b/client/src/pages/Downloads/Info/Info.tsx
@@ -19,7 +19,7 @@ export const Info = () => {
       </Box>
       <p>
         This will recreate the local database and import the latest data dump
-        directly. Please see the{' '}
+        directly. Please see the {' '}
         <Link
           href="https://github.com/dgidb/dgidb-v5/blob/main/README.md"
           target="_blank"

--- a/server/lib/tasks/db_bootstrapping.rake
+++ b/server/lib/tasks/db_bootstrapping.rake
@@ -9,7 +9,7 @@ namespace :dgidb do
   else
     data_submodule_path = File.join(Rails.root, 'data')
   end
-  data_file = File.join(data_submodule_path, 'data.sql')
+  data_file = File.join(data_submodule_path, 'dgidb_v5_latest.sql')
   version_file = File.join(Rails.root, 'VERSION')
   database_name = Rails.configuration.database_configuration[Rails.env]['database']
   host = Rails.configuration.database_configuration[Rails.env]['host']

--- a/server/lib/utils/snapshot_helpers.rb
+++ b/server/lib/utils/snapshot_helpers.rb
@@ -52,7 +52,7 @@ module Utils; module SnapshotHelpers
     unless Dir.exist? 'data'
       Dir.mkdir('data')
     end
-    system_or_die("wget -O #{destination} http://dgidb.org/data/data.sql")
+    system_or_die("wget -O #{destination} https://nch-igm-wagner-lab-public.s3.us-east-2.amazonaws.com/dgidb_v5_latest.sql")
   end
 
   private


### PR DESCRIPTION
Updated the dgidb:load_local method with the new hosted file location. Running the following rake task while inside the server directory should download the file and instantiate a local db:

`rake dgidb:load_local`