### PR TITLE
feat: make app more mobile friendly 

### DIFF
--- a/client/src/components/Browse/Sources/BrowseSources.scss
+++ b/client/src/components/Browse/Sources/BrowseSources.scss
@@ -6,7 +6,7 @@
   padding: 15px;
   .sources-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(325px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     grid-template-rows: repeat(1, 1fr);
     grid-column-gap: 15px;
     grid-row-gap: 15px;
@@ -38,6 +38,7 @@
     }
   }
   .filter-buttons {
+    flex-wrap: wrap;
     .MuiButton-outlined {
       color: var(--theme-primary) !important;
       border-color: var(--theme-primary) !important;

--- a/client/src/components/Browse/Sources/BrowseSources.scss
+++ b/client/src/components/Browse/Sources/BrowseSources.scss
@@ -6,7 +6,7 @@
   padding: 15px;
   .sources-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(325px, 1fr));
     grid-template-rows: repeat(1, 1fr);
     grid-column-gap: 15px;
     grid-row-gap: 15px;

--- a/client/src/components/Drug/DrugRecord/DrugRecord.scss
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.scss
@@ -9,6 +9,7 @@
 
   .drug-record-header {
     display: flex;
+    flex-wrap: wrap;
     flex-direction: row;
     align-items: end; // isn't aligning name object correctly
     margin-bottom: 0.5em;

--- a/client/src/components/Drug/DrugRecord/DrugRecord.tsx
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.tsx
@@ -219,8 +219,8 @@ export const DrugRecord: React.FC = () => {
           {generateXrefLink(drugId, ResultTypes.Drug, 'concept-id-link')}
         </Box>
       </Box>
-      <Box display={isMobile ? "block" : "flex"}>
-        <Box display="block" width={isMobile ? "100%" : "35%"}>
+      <Box display={isMobile ? 'block' : 'flex'}>
+        <Box display="block" width={isMobile ? '100%' : '35%'}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -248,7 +248,11 @@ export const DrugRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "65%"}>
+        <Box
+          ml={isMobile ? 0 : 1}
+          mt={isMobile ? 2 : 0}
+          width={isMobile ? '100%' : '65%'}
+        >
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Drug/DrugRecord/DrugRecord.tsx
+++ b/client/src/components/Drug/DrugRecord/DrugRecord.tsx
@@ -23,8 +23,10 @@ import { useGetDrugInteractions } from 'hooks/queries/useGetDrugInteractions';
 import { generateXrefLink } from 'utils/generateXrefLink';
 import { ResultTypes } from 'types/types';
 import { NotFoundError } from 'components/Shared/NotFoundError/NotFoundError';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 export const DrugRecord: React.FC = () => {
+  const isMobile = useGetIsMobile();
   const drugId = useParams().drug as string;
 
   // get drug attributes
@@ -217,8 +219,8 @@ export const DrugRecord: React.FC = () => {
           {generateXrefLink(drugId, ResultTypes.Drug, 'concept-id-link')}
         </Box>
       </Box>
-      <Box display="flex">
-        <Box display="block" width="35%">
+      <Box display={isMobile ? "block" : "flex"}>
+        <Box display="block" width={isMobile ? "100%" : "35%"}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -246,7 +248,7 @@ export const DrugRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={1} width="65%">
+        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "65%"}>
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Drug/DrugSummary/DrugSummary.scss
+++ b/client/src/components/Drug/DrugSummary/DrugSummary.scss
@@ -26,6 +26,7 @@
       max-width: 100% !important;
       border: none !important;
       margin-bottom: 20px;
+      margin-left: 0 !important;
     }
     .chart-section {
       flex-direction: column;
@@ -67,6 +68,7 @@
     }
 
     .summary-infographic-container {
+      margin-left: 5px;
       border: 1px var(--text-content) solid;
       padding: 10px;
       display: flex;
@@ -76,6 +78,7 @@
 
       .tabbed-view {
         align-items: flex-start !important;
+        min-width: fit-content;
       }
 
       .chart-section {

--- a/client/src/components/Drug/DrugSummary/DrugSummary.scss
+++ b/client/src/components/Drug/DrugSummary/DrugSummary.scss
@@ -13,15 +13,32 @@
     color: var(--text-content);
   }
 
+  @media screen and (max-width: 768px) {
+    .drug-summary-content {
+      display: block !important;
+    }
+    .interaction-count-container {
+      max-width: 100% !important;
+      border: none !important;
+      margin-bottom: 20px;
+    }
+    .summary-infographic-container {
+      max-width: 100% !important;
+      border: none !important;
+      margin-bottom: 20px;
+    }
+    .chart-section {
+      flex-direction: column;
+    }
+  }
+
   .drug-summary-content {
     display: flex;
 
     .interaction-count-container {
       border: 1px var(--text-content) solid;
-      margin-right: 7px;
       padding: 10px;
-      min-height: 400px;
-      width: 100px;
+      max-width: fit-content;
       flex-grow: 1;
 
       .interaction-count-header {
@@ -52,11 +69,10 @@
     .summary-infographic-container {
       border: 1px var(--text-content) solid;
       padding: 10px;
-      width: 80%;
-      justify-content: space-between;
       display: flex;
       flex-direction: column;
-      height: 500px;
+      width: 100%;
+      overflow-x: scroll;
 
       .tabbed-view {
         align-items: flex-start !important;

--- a/client/src/components/Drug/DrugSummary/DrugSummary.tsx
+++ b/client/src/components/Drug/DrugSummary/DrugSummary.tsx
@@ -161,7 +161,7 @@ const SummaryInfoDrug: React.FC<InfoProps> = ({
           <Tabs
             value={value}
             onChange={handleChange}
-            orientation={isMobile ? "horizontal" : "vertical"}
+            orientation={isMobile ? 'horizontal' : 'vertical'}
             textColor="secondary"
             indicatorColor="secondary"
           >
@@ -248,7 +248,7 @@ export const DrugSummary: React.FC<SummaryProps> = ({ drugs, isLoading }) => {
         alignItems="center"
         justifyContent="space-between"
       >
-        <Box display="flex" alignItems="center">
+        <Box display="flex" alignItems="center" flexWrap="wrap" mb={1}>
           <h1>Interaction Results</h1>
           <Box id="interaction-count" ml={2}>
             {interactionResults.length} total interactions

--- a/client/src/components/Drug/DrugSummary/DrugSummary.tsx
+++ b/client/src/components/Drug/DrugSummary/DrugSummary.tsx
@@ -13,7 +13,7 @@ import {
 import { InteractionTypeDrug } from 'components/Drug/DrugCharts';
 import { DirectionalityDrug } from 'components/Drug/DrugCharts';
 import { GeneCategories } from 'components/Drug/DrugCharts';
-import { Tab, Tabs } from '@mui/material';
+import { Alert, IconButton, Tab, Tabs } from '@mui/material';
 import TabPanel from 'components/Shared/TabPanel/TabPanel';
 
 // styles
@@ -21,6 +21,7 @@ import './DrugSummary.scss';
 import Box from '@mui/material/Box';
 import InteractionTable from 'components/Shared/InteractionTable/InteractionTable';
 import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
+import CloseIcon from '@mui/icons-material/Close';
 
 ChartJS.register(
   CategoryScale,
@@ -42,6 +43,13 @@ const InteractionCountDrug: React.FC<CountProps> = ({
   selectedDrugs,
   setSelectedDrugs,
 }) => {
+  const [hideAlert, setHideAlert] = React.useState(
+    window.localStorage.getItem('interaction-filter-tip-alert')
+  );
+  const handleCloseAlertTip = () => {
+    setHideAlert('true');
+    window.localStorage.setItem('interaction-filter-tip-alert', 'true');
+  };
   const toggleFilter = (drugName: string) => {
     if (selectedDrugs.includes(drugName)) {
       setSelectedDrugs(
@@ -54,6 +62,23 @@ const InteractionCountDrug: React.FC<CountProps> = ({
 
   return (
     <div className="interaction-count-container">
+      {!hideAlert && (
+        <Alert
+          severity="info"
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={handleCloseAlertTip}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+        >
+          You can filter by selecting the rows below
+        </Alert>
+      )}
       <div className="interaction-count-header">
         <div className="interaction-count-drug">
           <h2>

--- a/client/src/components/Drug/DrugSummary/DrugSummary.tsx
+++ b/client/src/components/Drug/DrugSummary/DrugSummary.tsx
@@ -22,6 +22,7 @@ import Box from '@mui/material/Box';
 import InteractionTable from 'components/Shared/InteractionTable/InteractionTable';
 import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
 import CloseIcon from '@mui/icons-material/Close';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 ChartJS.register(
   CategoryScale,
@@ -116,6 +117,7 @@ const SummaryInfoDrug: React.FC<InfoProps> = ({
   drugMatches,
   selectedDrugs,
 }) => {
+  const isMobile = useGetIsMobile();
   const [windowSize, setWindowSize] = useState(getWindowSize());
   const [value, setValue] = useState(0);
 
@@ -159,7 +161,7 @@ const SummaryInfoDrug: React.FC<InfoProps> = ({
           <Tabs
             value={value}
             onChange={handleChange}
-            orientation="vertical"
+            orientation={isMobile ? "horizontal" : "vertical"}
             textColor="secondary"
             indicatorColor="secondary"
           >

--- a/client/src/components/Gene/GeneRecord/GeneRecord.scss
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.scss
@@ -9,6 +9,7 @@
 
   .gene-record-header {
     display: flex;
+    flex-wrap: wrap;
     flex-direction: row;
     align-items: end; // isn't aligning name object correctly
     margin-bottom: 0.5em;

--- a/client/src/components/Gene/GeneRecord/GeneRecord.tsx
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.tsx
@@ -22,8 +22,10 @@ import { dropRedundantCites } from 'utils/dropRedundantCites';
 import { generateXrefLink } from 'utils/generateXrefLink';
 import { ResultTypes } from 'types/types';
 import { NotFoundError } from 'components/Shared/NotFoundError/NotFoundError';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 export const GeneRecord: React.FC = () => {
+  const isMobile = useGetIsMobile();
   const geneId: any = useParams().gene;
 
   // get gene attributes
@@ -215,8 +217,8 @@ export const GeneRecord: React.FC = () => {
           {generateXrefLink(geneId, ResultTypes.Gene, 'concept-id-link')}
         </Box>
       </Box>
-      <Box display="flex">
-        <Box display="block" width="35%">
+      <Box display={isMobile ? "block" : "flex"}>
+        <Box display="block" width={isMobile ? "100%" : "35%"}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -244,7 +246,7 @@ export const GeneRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={1} width="65%">
+        <Box ml={isMobile ? 0 : 1} width={isMobile ? "100%" : "65%"}>
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Gene/GeneRecord/GeneRecord.tsx
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.tsx
@@ -217,8 +217,8 @@ export const GeneRecord: React.FC = () => {
           {generateXrefLink(geneId, ResultTypes.Gene, 'concept-id-link')}
         </Box>
       </Box>
-      <Box display={isMobile ? "block" : "flex"}>
-        <Box display="block" width={isMobile ? "100%" : "35%"}>
+      <Box display={isMobile ? 'block' : 'flex'}>
+        <Box display="block" width={isMobile ? '100%' : '35%'}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -246,7 +246,11 @@ export const GeneRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "65%"}>
+        <Box
+          ml={isMobile ? 0 : 1}
+          mt={isMobile ? 2 : 0}
+          width={isMobile ? '100%' : '65%'}
+        >
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Gene/GeneRecord/GeneRecord.tsx
+++ b/client/src/components/Gene/GeneRecord/GeneRecord.tsx
@@ -246,7 +246,7 @@ export const GeneRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={isMobile ? 0 : 1} width={isMobile ? "100%" : "65%"}>
+        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "65%"}>
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Gene/GeneSummary/GeneSummary.scss
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.scss
@@ -27,6 +27,7 @@
       max-width: 100% !important;
       border: none !important;
       margin-bottom: 20px;
+      margin-left: 0 !important;
     }
     .chart-section {
       flex-direction: column;
@@ -70,6 +71,7 @@
     }
 
     .summary-infographic-container {
+      margin-left: 5px;
       border: 1px var(--text-content) solid;
       padding: 10px;
       display: flex;

--- a/client/src/components/Gene/GeneSummary/GeneSummary.scss
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.scss
@@ -21,10 +21,12 @@
     .interaction-count-container {
       max-width: 100% !important;
       border: none !important;
+      margin-bottom: 20px;
     }
     .summary-infographic-container {
       max-width: 100% !important;
       border: none !important;
+      margin-bottom: 20px;
     }
     .chart-section {
       flex-direction: column;
@@ -39,7 +41,6 @@
       border: 1px var(--text-content) solid;
       padding: 10px;
       max-width: fit-content;
-      min-height: fit-content;
       flex-grow: 1;
 
       .interaction-count-header {

--- a/client/src/components/Gene/GeneSummary/GeneSummary.scss
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.scss
@@ -14,15 +14,32 @@
     color: var(--text-content);
   }
 
+  @media screen and (max-width: 768px) {
+    .gene-summary-content {
+      display: block !important;
+    }
+    .interaction-count-container {
+      max-width: 100% !important;
+      border: none !important;
+    }
+    .summary-infographic-container {
+      max-width: 100% !important;
+      border: none !important;
+    }
+    .chart-section {
+      flex-direction: column;
+    }
+  }
+
   .gene-summary-content {
     display: flex;
     background-color: var(--background);
 
     .interaction-count-container {
       border: 1px var(--text-content) solid;
-      margin-right: 7px;
       padding: 10px;
-      min-height: 400px;
+      max-width: fit-content;
+      min-height: fit-content;
       flex-grow: 1;
 
       .interaction-count-header {
@@ -54,15 +71,16 @@
     .summary-infographic-container {
       border: 1px var(--text-content) solid;
       padding: 10px;
-      width: 80%;
-      justify-content: space-between;
       display: flex;
       flex-direction: column;
-      height: 500px;
+      min-height: 500px;
+      width: 100%;
+      overflow-x: scroll;
 
       .tabbed-view {
         align-items: flex-start !important;
         justify-content: center;
+        min-width: fit-content;
       }
 
       .chart-section {

--- a/client/src/components/Gene/GeneSummary/GeneSummary.tsx
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.tsx
@@ -169,7 +169,7 @@ const SummaryInfo: React.FC<InfoProps> = ({ geneMatches, selectedGenes }) => {
           <Tabs
             value={value}
             onChange={handleChange}
-            orientation={isMobile ? "horizontal" : "vertical"}
+            orientation={isMobile ? 'horizontal' : 'vertical'}
             textColor="secondary"
             indicatorColor="secondary"
           >
@@ -253,7 +253,7 @@ export const GeneSummary: React.FC<SummaryProps> = ({ genes, isLoading }) => {
         alignItems="center"
         justifyContent="space-between"
       >
-        <Box display="flex" alignItems="center">
+        <Box display="flex" alignItems="center" flexWrap="wrap" mb={1}>
           <h1>Interaction Results</h1>
           <Box id="interaction-count" ml={2}>
             {interactionResults.length} total interactions

--- a/client/src/components/Gene/GeneSummary/GeneSummary.tsx
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.tsx
@@ -18,8 +18,19 @@ import './GeneSummary.scss';
 import Box from '@mui/material/Box';
 import InteractionTable from 'components/Shared/InteractionTable/InteractionTable';
 import TableDownloader from 'components/Shared/TableDownloader/TableDownloader';
-import { Tab, Tabs } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  IconButton,
+  Tab,
+  Tabs,
+} from '@mui/material';
 import TabPanel from 'components/Shared/TabPanel/TabPanel';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CloseIcon from '@mui/icons-material/Close';
 
 ChartJS.register(
   CategoryScale,
@@ -41,6 +52,13 @@ const InteractionCount: React.FC<CountProps> = ({
   selectedGenes,
   setSelectedGenes,
 }) => {
+  const [hideAlert, setHideAlert] = React.useState(
+    window.localStorage.getItem('interaction-filter-tip-alert')
+  );
+  const handleCloseAlertTip = () => {
+    setHideAlert('true');
+    window.localStorage.setItem('interaction-filter-tip-alert', 'true');
+  };
   const toggleFilter = (geneName: string) => {
     if (selectedGenes.includes(geneName)) {
       setSelectedGenes(
@@ -53,6 +71,23 @@ const InteractionCount: React.FC<CountProps> = ({
 
   return (
     <div className="interaction-count-container">
+      {!hideAlert && (
+        <Alert
+          severity="info"
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={handleCloseAlertTip}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+        >
+          You can filter by selecting the rows below
+        </Alert>
+      )}
       <div className="interaction-count-header">
         <div className="interaction-count-gene">
           <h2>
@@ -65,6 +100,7 @@ const InteractionCount: React.FC<CountProps> = ({
           </h2>
         </div>
       </div>
+
       {geneMatches?.map((gene: any, i: number) => {
         return (
           <div
@@ -161,6 +197,7 @@ interface SummaryProps {
 }
 
 export const GeneSummary: React.FC<SummaryProps> = ({ genes, isLoading }) => {
+  const isMobile = useGetIsMobile();
   const [interactionResults, setInteractionResults] = useState<any[]>([]);
   const [selectedGenes, setSelectedGenes] = useState<string[]>([]);
   const [displayedInteractionResults, setDisplayedInteractionResults] =
@@ -197,6 +234,7 @@ export const GeneSummary: React.FC<SummaryProps> = ({ genes, isLoading }) => {
   }, [selectedGenes, interactionResults]);
 
   const geneMatches = genes?.map((geneMatch: any) => geneMatch.matches[0]);
+
   return (
     <div className="gene-summary-container">
       <h1>Gene Summary</h1>

--- a/client/src/components/Gene/GeneSummary/GeneSummary.tsx
+++ b/client/src/components/Gene/GeneSummary/GeneSummary.tsx
@@ -125,6 +125,7 @@ interface InfoProps {
 }
 
 const SummaryInfo: React.FC<InfoProps> = ({ geneMatches, selectedGenes }) => {
+  const isMobile = useGetIsMobile();
   const [windowSize, setWindowSize] = useState(getWindowSize());
   const [value, setValue] = useState(0);
 
@@ -168,7 +169,7 @@ const SummaryInfo: React.FC<InfoProps> = ({ geneMatches, selectedGenes }) => {
           <Tabs
             value={value}
             onChange={handleChange}
-            orientation="vertical"
+            orientation={isMobile ? "horizontal" : "vertical"}
             textColor="secondary"
             indicatorColor="secondary"
           >

--- a/client/src/components/GeneCategories/AmbiguousMatchCard/AmbiguousMatchCard.tsx
+++ b/client/src/components/GeneCategories/AmbiguousMatchCard/AmbiguousMatchCard.tsx
@@ -67,7 +67,7 @@ export const AmbiguousMatchesCard: React.FC<Props> = ({ match }) => {
           </Box>
         ) : (
           <Typography fontStyle="italic">
-            STK1 is ambiguous. Please select context from drop down.
+            {match.searchTerm} is ambiguous. Please select context from drop down.
           </Typography>
         )}
       </AccordionDetails>

--- a/client/src/components/GeneCategories/AmbiguousMatchCard/AmbiguousMatchCard.tsx
+++ b/client/src/components/GeneCategories/AmbiguousMatchCard/AmbiguousMatchCard.tsx
@@ -67,7 +67,8 @@ export const AmbiguousMatchesCard: React.FC<Props> = ({ match }) => {
           </Box>
         ) : (
           <Typography fontStyle="italic">
-            {match.searchTerm} is ambiguous. Please select context from drop down.
+            {match.searchTerm} is ambiguous. Please select context from drop
+            down.
           </Typography>
         )}
       </AccordionDetails>

--- a/client/src/components/Interaction/InteractionRecord/InteractionRecord.tsx
+++ b/client/src/components/Interaction/InteractionRecord/InteractionRecord.tsx
@@ -18,8 +18,10 @@ import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import { truncateDecimals } from 'utils/format';
 import { Alert } from '@mui/material';
 import { NotFoundError } from 'components/Shared/NotFoundError/NotFoundError';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 export const InteractionRecord: React.FC = () => {
+  const isMobile = useGetIsMobile();
   const interactionId = useParams().id;
   const { data } = useGetInteractionRecord(interactionId!);
   const interactionData = data?.interaction;
@@ -168,8 +170,8 @@ export const InteractionRecord: React.FC = () => {
           </a>
         </Box>
       </Box>
-      <Box display="flex">
-        <Box display="block" width="45%">
+      <Box display={isMobile ? "block" : "flex"}>
+        <Box display="block" width={isMobile ? "100%" : "45%"}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -197,7 +199,7 @@ export const InteractionRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={1} width="55%">
+        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "55%"}>
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Interaction/InteractionRecord/InteractionRecord.tsx
+++ b/client/src/components/Interaction/InteractionRecord/InteractionRecord.tsx
@@ -170,8 +170,8 @@ export const InteractionRecord: React.FC = () => {
           </a>
         </Box>
       </Box>
-      <Box display={isMobile ? "block" : "flex"}>
-        <Box display="block" width={isMobile ? "100%" : "45%"}>
+      <Box display={isMobile ? 'block' : 'flex'}>
+        <Box display="block" width={isMobile ? '100%' : '45%'}>
           {sectionsMap.map((section) => {
             return (
               <Accordion key={section.name} defaultExpanded>
@@ -199,7 +199,11 @@ export const InteractionRecord: React.FC = () => {
             );
           })}
         </Box>
-        <Box ml={isMobile ? 0 : 1} mt={isMobile ? 2 : 0} width={isMobile ? "100%" : "55%"}>
+        <Box
+          ml={isMobile ? 0 : 1}
+          mt={isMobile ? 2 : 0}
+          width={isMobile ? '100%' : '55%'}
+        >
           <Accordion defaultExpanded>
             <AccordionSummary
               style={{

--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -109,26 +109,26 @@ const Header: React.FC = () => {
 
   const mobileNavItems = [
     {
-      text: "Browse Categories",
-      navPath: "/browse/categories",
+      text: 'Browse Categories',
+      navPath: '/browse/categories',
       icon: <CategoryIcon />,
     },
     {
-      text: "Browse Sources",
-      navPath: "/browse/sources",
+      text: 'Browse Sources',
+      navPath: '/browse/sources',
       icon: <SourceIcon />,
     },
     {
-      text: "About",
-      navPath: "/about",
+      text: 'About',
+      navPath: '/about',
       icon: <InfoIcon />,
     },
     {
-      text: "Downloads",
-      navPath: "/downloads",
+      text: 'Downloads',
+      navPath: '/downloads',
       icon: <CloudDownloadIcon />,
-    }
-  ]
+    },
+  ];
 
   const mobileNavMenu = (
     <>
@@ -141,19 +141,21 @@ const Header: React.FC = () => {
         onClose={() => setShowMenuDrawer(false)}
       >
         <List>
-        {mobileNavItems.map(item => {
-          return (<ListItem>
-            <ListItemButton
-              onClick={() => {
-                setShowMenuDrawer(false);
-                navigate(item.navPath);
-              }}
-            >
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
-          </ListItem>)
-        })}
+          {mobileNavItems.map((item) => {
+            return (
+              <ListItem>
+                <ListItemButton
+                  onClick={() => {
+                    setShowMenuDrawer(false);
+                    navigate(item.navPath);
+                  }}
+                >
+                  <ListItemIcon>{item.icon}</ListItemIcon>
+                  <ListItemText primary={item.text} />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
         </List>
       </Drawer>
     </>

--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -141,9 +141,9 @@ const Header: React.FC = () => {
         onClose={() => setShowMenuDrawer(false)}
       >
         <List>
-          {mobileNavItems.map((item) => {
+          {mobileNavItems.map((item, index) => {
             return (
-              <ListItem>
+              <ListItem key={index}>
                 <ListItemButton
                   onClick={() => {
                     setShowMenuDrawer(false);

--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -15,13 +15,25 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Drawer,
   IconButton,
   Link,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
   Menu,
   MenuItem,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ReleaseInformation from 'components/Shared/ReleaseInformation/ReleaseInformation';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
+import MenuIcon from '@mui/icons-material/Menu';
+import InfoIcon from '@mui/icons-material/Info';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import CategoryIcon from '@mui/icons-material/Category';
+import SourceIcon from '@mui/icons-material/Source';
 
 type MainLayoutProps = {
   children: React.ReactNode;
@@ -32,6 +44,7 @@ const Header: React.FC = () => {
   const [hideBanner, setHideBanner] = useState(
     window.localStorage.getItem('banner-closed')
   );
+  const [showMenuDrawer, setShowMenuDrawer] = useState(false);
 
   const handleOpen = (event: any) => {
     setAnchorEl(event.currentTarget);
@@ -47,55 +60,112 @@ const Header: React.FC = () => {
   };
 
   const navigate = useNavigate();
+  const isMobile = useGetIsMobile();
+
+  const desktopNavMenu = (
+    <nav>
+      <ul>
+        <li>
+          <Button className="browse-button" onClick={handleOpen}>
+            Browse
+          </Button>
+          <Menu
+            id="simple-menu"
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <MenuItem
+              onClick={() => {
+                handleClose();
+                navigate('/browse/categories');
+              }}
+            >
+              Categories
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                handleClose();
+                navigate('/browse/sources');
+              }}
+            >
+              Sources
+            </MenuItem>
+          </Menu>
+        </li>
+        <li onClick={() => navigate('/about')}>About</li>
+        <li onClick={() => navigate('/downloads')}>Downloads</li>
+      </ul>
+    </nav>
+  );
+
+  const mobileNavItems = [
+    {
+      text: "Browse Categories",
+      navPath: "/browse/categories",
+      icon: <CategoryIcon />,
+    },
+    {
+      text: "Browse Sources",
+      navPath: "/browse/sources",
+      icon: <SourceIcon />,
+    },
+    {
+      text: "About",
+      navPath: "/about",
+      icon: <InfoIcon />,
+    },
+    {
+      text: "Downloads",
+      navPath: "/downloads",
+      icon: <CloudDownloadIcon />,
+    }
+  ]
+
+  const mobileNavMenu = (
+    <>
+      <IconButton onClick={() => setShowMenuDrawer(true)}>
+        <MenuIcon htmlColor="white" />
+      </IconButton>
+      <Drawer
+        anchor="right"
+        open={showMenuDrawer}
+        onClose={() => setShowMenuDrawer(false)}
+      >
+        <List>
+        {mobileNavItems.map(item => {
+          return (<ListItem>
+            <ListItemButton
+              onClick={() => {
+                setShowMenuDrawer(false);
+                navigate(item.navPath);
+              }}
+            >
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.text} />
+            </ListItemButton>
+          </ListItem>)
+        })}
+        </List>
+      </Drawer>
+    </>
+  );
 
   return (
     <header>
-      <Box display="flex">
+      <Box display="flex" justifyContent="space-between">
         <div className="header-logo" onClick={() => navigate('/')}>
           DGIdb
         </div>
-        <nav>
-          <ul>
-            <li>
-              <Button className="browse-button" onClick={handleOpen}>
-                Browse
-              </Button>
-              <Menu
-                id="simple-menu"
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={handleClose}
-                anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'center',
-                }}
-                transformOrigin={{
-                  vertical: 'top',
-                  horizontal: 'center',
-                }}
-              >
-                <MenuItem
-                  onClick={() => {
-                    handleClose();
-                    navigate('/browse/categories');
-                  }}
-                >
-                  Categories
-                </MenuItem>
-                <MenuItem
-                  onClick={() => {
-                    handleClose();
-                    navigate('/browse/sources');
-                  }}
-                >
-                  Sources
-                </MenuItem>
-              </Menu>
-            </li>
-            <li onClick={() => navigate('/about')}>About</li>
-            <li onClick={() => navigate('/downloads')}>Downloads</li>
-          </ul>
-        </nav>
+        {isMobile ? mobileNavMenu : desktopNavMenu}
       </Box>
       {!hideBanner ? (
         <Box className="header-banner">

--- a/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTerms.scss
+++ b/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTerms.scss
@@ -3,7 +3,7 @@
   background-color: var(--soft-background);
   border: 2px solid var(--soft-background);
   border-radius: 5px;
-  margin-left: 20px;
+  margin-left: 5px;
   padding: 10px;
 }
 

--- a/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTermsSummary.tsx
+++ b/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTermsSummary.tsx
@@ -4,6 +4,7 @@ import { Box, CircularProgress, Icon } from '@mui/material';
 import AmbiguousResult from './AmbiguousResult';
 import './AmbiguousTerms.scss';
 import { ResultTypes } from 'types/types';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 interface AmbiguousTermsSummaryProps {
   resultType: ResultTypes;
@@ -18,9 +19,10 @@ export const AmbiguousTermsSummary: React.FC<AmbiguousTermsSummaryProps> = ({
   ambiguousTerms,
   unmatchedTerms,
 }) => {
+  const isMobile = useGetIsMobile();
   return !isLoading ? (
-    <Box display="flex" justifyContent="space-between" minHeight="50px">
-      <Box width={unmatchedTerms?.length > 0 ? '80%' : '100%'}>
+    <Box display="flex" justifyContent="space-between" minHeight="50px" flexWrap={isMobile ? "wrap" : "nowrap"}>
+      <Box width={unmatchedTerms?.length > 0 && !isMobile  ? '80%' : '100%'}>
         {ambiguousTerms?.length > 0 ? (
           ambiguousTerms?.map((term: any) => {
             return (
@@ -40,7 +42,7 @@ export const AmbiguousTermsSummary: React.FC<AmbiguousTermsSummaryProps> = ({
         )}
       </Box>
       {unmatchedTerms?.length > 0 && (
-        <Box width="20%" className="unmatched-terms">
+        <Box width="20%" minWidth="fit-content" className="unmatched-terms" mt={isMobile ? 2 : 0}>
           <h3>
             <b>Unmatched Terms:</b>
           </h3>

--- a/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTermsSummary.tsx
+++ b/client/src/components/Shared/AmbiguousTermsSummary/AmbiguousTermsSummary.tsx
@@ -21,8 +21,13 @@ export const AmbiguousTermsSummary: React.FC<AmbiguousTermsSummaryProps> = ({
 }) => {
   const isMobile = useGetIsMobile();
   return !isLoading ? (
-    <Box display="flex" justifyContent="space-between" minHeight="50px" flexWrap={isMobile ? "wrap" : "nowrap"}>
-      <Box width={unmatchedTerms?.length > 0 && !isMobile  ? '80%' : '100%'}>
+    <Box
+      display="flex"
+      justifyContent="space-between"
+      minHeight="50px"
+      flexWrap={isMobile ? 'wrap' : 'nowrap'}
+    >
+      <Box width={unmatchedTerms?.length > 0 && !isMobile ? '80%' : '100%'}>
         {ambiguousTerms?.length > 0 ? (
           ambiguousTerms?.map((term: any) => {
             return (
@@ -42,7 +47,12 @@ export const AmbiguousTermsSummary: React.FC<AmbiguousTermsSummaryProps> = ({
         )}
       </Box>
       {unmatchedTerms?.length > 0 && (
-        <Box width="20%" minWidth="fit-content" className="unmatched-terms" mt={isMobile ? 2 : 0}>
+        <Box
+          width="20%"
+          minWidth="fit-content"
+          className="unmatched-terms"
+          mt={isMobile ? 2 : 0}
+        >
           <h3>
             <b>Unmatched Terms:</b>
           </h3>

--- a/client/src/components/Shared/InteractionTable/InteractionTable.tsx
+++ b/client/src/components/Shared/InteractionTable/InteractionTable.tsx
@@ -45,14 +45,14 @@ export const InteractionTable: React.FC<Props> = ({
   const termColumn = {
     field: 'term',
     headerName: 'Term',
-    flex: 0.5,
+    flex: 0.65,
     minWidth: 0,
   };
 
   const geneColumn = {
     field: 'gene',
     headerName: 'Gene',
-    flex: 0.5,
+    flex: 0.65,
     minWidth: 0,
     renderCell: (params: any) => (
       <a
@@ -208,7 +208,7 @@ export const InteractionTable: React.FC<Props> = ({
 
   return !isLoading ? (
     <Box className="interaction-table-container">
-      <Box width="100%" height="500px" display="flex">
+      <Box width="100%" height="500px" display="flex" overflow="scroll">
         <DataGrid
           onRowClick={handleEvent}
           columns={columns}

--- a/client/src/components/Shared/SearchBar/SearchBar.tsx
+++ b/client/src/components/Shared/SearchBar/SearchBar.tsx
@@ -14,6 +14,7 @@ import { GlobalClientContext } from 'stores/Global/GlobalClient';
 import { ActionTypes } from 'stores/Global/reducers';
 import { useGetNameSuggestions } from 'hooks/queries/useGetNameSuggestions';
 import { SearchTypes } from 'types/types';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 type SearchBarProps = {
   handleSubmit: () => void;
@@ -21,6 +22,7 @@ type SearchBarProps = {
 
 const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
   const { state, dispatch } = useContext(GlobalClientContext);
+  const isMobile = useGetIsMobile();
   const [searchType, setSearchType] = React.useState<SearchTypes>(
     state.interactionMode
   );
@@ -129,14 +131,15 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
 
   return (
     <>
-      <Box id="search-bar-container" width="90%">
-        <Box display="flex">
-          <Box>
+      <Box id="search-bar-container" width={isMobile ? "95%" : "75%" }>
+        <Box display="flex" flexWrap={isMobile ? "wrap" : "nowrap"}>
+          <Box width={isMobile ? "100%" : "fit-content"}>
             <Select
               value={state.interactionMode || searchType}
               defaultValue={state.interactionMode || SearchTypes.Gene}
               onChange={handleChange}
               classes={{ select: 'search-type-select' }}
+              fullWidth={isMobile}
             >
               <MenuItem value={SearchTypes.Gene}>Interactions by Gene</MenuItem>
               <MenuItem value={SearchTypes.Drug}>Interactions by Drug</MenuItem>
@@ -145,7 +148,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
               </MenuItem>
             </Select>
           </Box>
-          <Box display="block" ml={1} width="100%">
+          <Box display="block" ml={1} width="100%" mt={isMobile ? 2 : 0}>
             <Autocomplete
               multiple
               filterSelectedOptions

--- a/client/src/components/Shared/SearchBar/SearchBar.tsx
+++ b/client/src/components/Shared/SearchBar/SearchBar.tsx
@@ -131,9 +131,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
 
   return (
     <>
-      <Box id="search-bar-container" width={isMobile ? "95%" : "75%" }>
-        <Box display="flex" flexWrap={isMobile ? "wrap" : "nowrap"}>
-          <Box width={isMobile ? "100%" : "fit-content"}>
+      <Box id="search-bar-container" width={isMobile ? '95%' : '75%'}>
+        <Box display="flex" flexWrap={isMobile ? 'wrap' : 'nowrap'}>
+          <Box width={isMobile ? '100%' : 'fit-content'}>
             <Select
               value={state.interactionMode || searchType}
               defaultValue={state.interactionMode || SearchTypes.Gene}

--- a/client/src/components/Shared/SearchBar/SearchBar.tsx
+++ b/client/src/components/Shared/SearchBar/SearchBar.tsx
@@ -117,6 +117,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
     // populate tags from state if nothing entered
     if (state.searchTerms?.length > 0 && selectedOptions?.length === 0) {
       setSelectedOptions(
+        // extra security to ensure no duplicates are displayed
         [...new Set(state.searchTerms)].map((option) => {
           return { suggestion: option };
         })

--- a/client/src/components/Shared/SearchBar/SearchBar.tsx
+++ b/client/src/components/Shared/SearchBar/SearchBar.tsx
@@ -115,14 +115,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
 
   useEffect(() => {
     // populate tags from state if nothing entered
-    if (selectedOptions?.length !== 0) {
-      selectedOptions.map((option) => {
-        dispatch({ type: ActionTypes.AddTerm, payload: option.suggestion });
-      });
-      // populate
-    } else if (state.searchTerms?.length > 0 && selectedOptions?.length === 0) {
+    if (state.searchTerms?.length > 0 && selectedOptions?.length === 0) {
       setSelectedOptions(
-        state.searchTerms.map((option) => {
+        [...new Set(state.searchTerms)].map((option) => {
           return { suggestion: option };
         })
       );

--- a/client/src/components/Shared/SearchBar/SearchBar.tsx
+++ b/client/src/components/Shared/SearchBar/SearchBar.tsx
@@ -129,7 +129,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
 
   return (
     <>
-      <Box>
+      <Box id="search-bar-container" width="90%">
         <Box display="flex">
           <Box>
             <Select
@@ -145,7 +145,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
               </MenuItem>
             </Select>
           </Box>
-          <Box display="block" ml={1}>
+          <Box display="block" ml={1} width="100%">
             <Autocomplete
               multiple
               filterSelectedOptions
@@ -153,7 +153,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ handleSubmit }) => {
               options={autocompleteOptions}
               getOptionLabel={(option: any) => option.suggestion}
               renderInput={(params) => (
-                <Box width={650}>
+                <Box>
                   <TextField
                     {...params}
                     variant="standard"

--- a/client/src/components/Shared/TabPanel/TabPanel.tsx
+++ b/client/src/components/Shared/TabPanel/TabPanel.tsx
@@ -21,7 +21,7 @@ function TabPanel(props: TabPanelProps) {
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          <Box>{children}</Box>
         </Box>
       )}
     </div>

--- a/client/src/hooks/shared/useGetIsMobile.tsx
+++ b/client/src/hooks/shared/useGetIsMobile.tsx
@@ -1,0 +1,6 @@
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+export function useGetIsMobile() {
+  const isMobile = useMediaQuery('(max-width: 1000px)');
+  return isMobile;
+}

--- a/client/src/hooks/shared/useGetIsMobile.tsx
+++ b/client/src/hooks/shared/useGetIsMobile.tsx
@@ -1,6 +1,6 @@
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 export function useGetIsMobile() {
-  const isMobile = useMediaQuery('(max-width: 600px)');
+  const isMobile = useMediaQuery('(max-width: 768px)');
   return isMobile;
 }

--- a/client/src/hooks/shared/useGetIsMobile.tsx
+++ b/client/src/hooks/shared/useGetIsMobile.tsx
@@ -1,6 +1,6 @@
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 export function useGetIsMobile() {
-  const isMobile = useMediaQuery('(max-width: 1000px)');
+  const isMobile = useMediaQuery('(max-width: 600px)');
   return isMobile;
 }

--- a/client/src/pages/About/About.tsx
+++ b/client/src/pages/About/About.tsx
@@ -10,43 +10,94 @@ import { FAQ } from './SubSections/FAQ';
 import { KnownDataClients } from './SubSections/KnownDataClients';
 import { Contact } from './SubSections/Contact';
 import { TypesTable } from 'components/About/InteractionClaimTypes/TypesTable';
-import { Box, Link } from '@mui/material';
+import { Box, Button, Link, Menu, MenuItem } from '@mui/material';
 
 // styles
 import './About.scss';
+import { useGetIsMobile } from 'hooks/shared/useGetIsMobile';
 
 export const About = () => {
+  const isMobile = useGetIsMobile();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const aboutSections = [
+    {
+      name: 'About',
+      href: '#about'
+    },
+    {
+      name: 'Publications',
+      href: '#publications'
+    },
+    {
+      name: 'Types/Directionalities',
+      href: '#interaction-types'
+    },
+    {
+      name: 'Interaction Score',
+      href: '#interaction-scores'
+    },
+    {
+      name: 'FAQ',
+      href: '#faq'
+    },
+    {
+      name: 'Known Data Clients',
+      href: '#known-data-clients'
+    },
+    {
+      name: 'Contact',
+      href: '#contact'
+    },
+    {
+      name: 'Current Contributors',
+      href: '#current-contributors'
+    },
+    {
+      name: 'Acknowledgements',
+      href: '#acknowledgements'
+    },
+  ]
+
+  const jumpToButton = (
+    <>
+      <Button id="jump-to-button" variant="contained" onClick={handleClick} style={{position: "fixed", bottom: 10, right: 5}}>
+        Jump To
+      </Button>
+      <Menu
+        id="jump-to-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+      >
+        {aboutSections.map((section, index) => {
+          return (
+            <MenuItem key={index}><Link href={section.href}>{section.name}</Link></MenuItem>
+          )
+        })}
+      </Menu>
+    </>
+  );
+
   return (
     <div className="about-page-container">
+      {isMobile ? jumpToButton : ""}
       <Box>
-        <div className="table-of-contents-container">
-          <Box mb={1} mt={1}>
-            <Link href="#about">About</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#publications">Publications</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#interaction-types">Types/Directionalities</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#interaction-scores">Interaction Score</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#faq">FAQ</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#known-data-clients">Known Data Clients</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#contact">Contact</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#current-contributors">Current Contributors</Link>
-          </Box>
-          <Box mb={1}>
-            <Link href="#acknowledgements">Acknowledgements</Link>
-          </Box>
+        <div className="table-of-contents-container" hidden={isMobile}>
+          {aboutSections.map((section, index) => {
+            return (
+              <Box mb={1} key={index}>
+                <Link href={section.href}>{section.name}</Link>
+              </Box>
+            )
+          })}
         </div>
       </Box>
       <div className="about-content-container">

--- a/client/src/pages/About/About.tsx
+++ b/client/src/pages/About/About.tsx
@@ -30,45 +30,50 @@ export const About = () => {
   const aboutSections = [
     {
       name: 'About',
-      href: '#about'
+      href: '#about',
     },
     {
       name: 'Publications',
-      href: '#publications'
+      href: '#publications',
     },
     {
       name: 'Types/Directionalities',
-      href: '#interaction-types'
+      href: '#interaction-types',
     },
     {
       name: 'Interaction Score',
-      href: '#interaction-scores'
+      href: '#interaction-scores',
     },
     {
       name: 'FAQ',
-      href: '#faq'
+      href: '#faq',
     },
     {
       name: 'Known Data Clients',
-      href: '#known-data-clients'
+      href: '#known-data-clients',
     },
     {
       name: 'Contact',
-      href: '#contact'
+      href: '#contact',
     },
     {
       name: 'Current Contributors',
-      href: '#current-contributors'
+      href: '#current-contributors',
     },
     {
       name: 'Acknowledgements',
-      href: '#acknowledgements'
+      href: '#acknowledgements',
     },
-  ]
+  ];
 
   const jumpToButton = (
     <>
-      <Button id="jump-to-button" variant="contained" onClick={handleClick} style={{position: "fixed", bottom: 10, right: 5}}>
+      <Button
+        id="jump-to-button"
+        variant="contained"
+        onClick={handleClick}
+        style={{ position: 'fixed', bottom: 10, right: 5 }}
+      >
         Jump To
       </Button>
       <Menu
@@ -79,8 +84,10 @@ export const About = () => {
       >
         {aboutSections.map((section, index) => {
           return (
-            <MenuItem key={index}><Link href={section.href}>{section.name}</Link></MenuItem>
-          )
+            <MenuItem key={index}>
+              <Link href={section.href}>{section.name}</Link>
+            </MenuItem>
+          );
         })}
       </Menu>
     </>
@@ -88,7 +95,7 @@ export const About = () => {
 
   return (
     <div className="about-page-container">
-      {isMobile ? jumpToButton : ""}
+      {isMobile ? jumpToButton : ''}
       <Box>
         <div className="table-of-contents-container" hidden={isMobile}>
           {aboutSections.map((section, index) => {
@@ -96,7 +103,7 @@ export const About = () => {
               <Box mb={1} key={index}>
                 <Link href={section.href}>{section.name}</Link>
               </Box>
-            )
+            );
           })}
         </div>
       </Box>

--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -15,7 +15,7 @@
     font-size: 20px;
     font-family: 'Work Sans';
     font-weight: 300;
-    width: 560px;
+    width: 50%;
     display: flex;
     justify-content: center;
     text-align: center;

--- a/client/src/pages/Home/Home.scss
+++ b/client/src/pages/Home/Home.scss
@@ -8,7 +8,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 80vh;
+  min-height: 75vh;
 
   .home-blurb {
     margin-top: 160px;

--- a/client/src/routes/public.tsx
+++ b/client/src/routes/public.tsx
@@ -102,17 +102,3 @@ export const Routes = () => {
 
   return <>{element}</>;
 };
-
-// export const publicRoutes = [
-//   {
-//     path: '/',
-//     element: <App />,
-//     children: [
-//       { path: '/genes/*', element: <GeneRecord /> },
-//       { path: '/results', element: <Results /> },
-//       { path: '/about', element: <About /> },
-//       { path: '/', element: <Home /> },
-//       { path: '*', element: <Navigate to="." /> },
-//     ],
-//   }
-// ];

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "baseUrl": "src",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
Opening this draft PR to help me keep track of my progress and what I still need to do. 

This PR will close #461 

Done so far:
- added hook to return boolean value if a screen size we consider "mobile" size is used
- made nav menu hamburger menu on small screen sizes + added a drawer and icons
- fixed majority of issues on the gene, drug, and interaction pages (stack each component vertically at 100% width)
- made components on home page not go off-screen 
- home page
- fixed bug where search results were getting repeated (not mobile-specific but needed a bandaid)
- point to ES6 because it's superior
- fixed about page (added floating button to jump between sections for mobile)
- browse sources - changed grid population to only display as many cards as possible given the space, otherwise it will wrap to next line. The noticeable change here will be that there will be more cards in a row for bigger screen sizes 
- make data tables fit nicely and scrollable on all screen sizes
- make results pages functional + look nice on all screen sizes
- reactive display for ambiguous/unmatched terms

Did not get to:
- browse categories - make drawer for selecting/deselecting categories?
- API page 
- 