### PR TITLE
Use case insensitive, left anchored matching for drug names 

### DIFF
--- a/server/app/graphql/resolvers/drugs.rb
+++ b/server/app/graphql/resolvers/drugs.rb
@@ -13,8 +13,10 @@ class Resolvers::Drugs < GraphQL::Schema::Resolver
     scope.where(id: value)
   end
 
-  option(:names, type: [String], description: 'Substring filtering on a list of drug names.') do |scope, value|
-    scope.where(name: value.map(&:upcase))
+  option(:names, type: [String], description: 'Left anchored filtering on a list of drug names.') do |scope, value|
+    text = 'name ILIKE ?'
+    clause = Array.new(value.size, text).join(" OR ")
+    scope.where(clause, *value.map {|v| "#{v}%"})
   end
 
   option(:name, type: String, description: 'Left anchored string search on drug name') do |scope, value|


### PR DESCRIPTION
closes #476 

The previous version was using `IN` and passing an array which will exact match. Unfortunately, as far as I'm aware, there is no equivalent `ILIKE IN` so we need to build the query up manually.

`Array.new(size, value)` initializes a new array of strings with the value `'name ILIKE ?'` equivalent to the number of drug names passed in.

`value.map {|v| "#{v}%"}` tacks on the `%` for left anchored wildcard matching to each search term, and then the `*` splats those terms out into parameters to the `where` clause. So you end up with something that will look like

`scope.where("name ILIKE ? OR name ILIKE ?", 'foo', 'bar')`. This allows us to dynamically build the query while still using ActiveRecord's built in query parameterization/escaping.

