### PR TITLE
Add support for GA4GH service info query

### DIFF
--- a/client/src/pages/About/SubSections/Contact.tsx
+++ b/client/src/pages/About/SubSections/Contact.tsx
@@ -6,7 +6,7 @@ export const Contact = () => {
     <div className="contact-section-container doc-section">
       <div>
         <p>
-          DGIdb was developed at The McDonnell Genome Institute, Washington
+          DGIdb was initially developed at The McDonnell Genome Institute, Washington
           University School of Medicine. If you have a source of information
           related to the druggable genome you would like us to incorporate,
           please contact us at{' '}
@@ -25,11 +25,11 @@ export const Contact = () => {
       <div className="left-section">
         <h4>
           <Link
-            href="http://genome.wustl.edu/"
+            href="https://griffithlab.org"
             target="_blank"
             rel="noreferrer"
           >
-            The McDonnell Genome Institute
+            The Griffith Laboratory
           </Link>
         </h4>
         <p>Washington University</p>

--- a/client/src/pages/About/SubSections/Contact.tsx
+++ b/client/src/pages/About/SubSections/Contact.tsx
@@ -6,10 +6,10 @@ export const Contact = () => {
     <div className="contact-section-container doc-section">
       <div>
         <p>
-          DGIdb was initially developed at The McDonnell Genome Institute, Washington
-          University School of Medicine. If you have a source of information
-          related to the druggable genome you would like us to incorporate,
-          please contact us at{' '}
+          DGIdb was initially developed at The McDonnell Genome Institute,
+          Washington University School of Medicine. If you have a source of
+          information related to the druggable genome you would like us to
+          incorporate, please contact us at{' '}
           <Link href="mailto:help@dgidb.org">help@dgidb.org.</Link>
         </p>
         <p>
@@ -24,11 +24,7 @@ export const Contact = () => {
 
       <div className="left-section">
         <h4>
-          <Link
-            href="https://griffithlab.org"
-            target="_blank"
-            rel="noreferrer"
-          >
+          <Link href="https://griffithlab.org" target="_blank" rel="noreferrer">
             The Griffith Laboratory
           </Link>
         </h4>

--- a/server/app/graphql/types/meta_type.rb
+++ b/server/app/graphql/types/meta_type.rb
@@ -1,9 +1,70 @@
 module Types
   class MetaType < Types::BaseObject
-    field :data_version, String, null: false
+    field :id, String, null: false, description: 'Unique identifier for service.'
+    field :data_version, String, null: false, description: 'Version of the data being served by DGIdb'
+    field :name, String, null: false, description: 'Human readable name of the service'
+    field :type, Types::ServiceType, null: false
+    field :description, String, null: false
+    field :organization, Types::OrganizationType, null: false
+    field :contact_url, String, null: false, description: 'URL of the contact for the provider of this service'
+    field :documentation_url, String, null: false, description: 'URL of the documentation of this service'
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'Timestamp describing when the service was first deployed and available'
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: 'Timestamp describing when the service was last updated'
+    field :environment, String, null: false, description: 'Environment the service is running in'
+    field :version, String, null: false, description: 'Version of the service being described'
+
+    def id
+      'org.dgidb.graphql'
+    end
 
     def data_version
       DATA_VERSION
     end
+
+    def name
+      'DGIdb'
+    end
+
+     def type
+       {}
+     end
+
+     def description
+       "An open-source search engine for drug-gene interactions and the druggable genome."
+     end
+
+     def organization
+       {}
+     end
+
+     def contact_url
+       "mailto:help@dgidb.org"
+     end
+
+     def documentation_url
+       'https://dgidb.org/api/graphiql'
+     end
+
+     def created_at
+       #version 5.0.0 initial release on GitHub
+       DateTime.parse("October 20, 2023 8:51 AM CDT")
+     end
+
+     def updated_at
+       DateTime.parse(github_release&.dig("published_at"))
+     end
+
+     def environment
+       Rails.env
+     end
+
+     def version
+       github_release&.dig("tag_name")
+     end
+
+     private
+     def github_release
+       @rel ||= GithubRelease.current
+     end
   end
 end

--- a/server/app/graphql/types/meta_type.rb
+++ b/server/app/graphql/types/meta_type.rb
@@ -1,0 +1,9 @@
+module Types
+  class MetaType < Types::BaseObject
+    field :data_version, String, null: false
+
+    def data_version
+      DATA_VERSION
+    end
+  end
+end

--- a/server/app/graphql/types/organization_type.rb
+++ b/server/app/graphql/types/organization_type.rb
@@ -1,0 +1,14 @@
+module Types
+  class OrganizationType < Types::BaseObject
+    field :name, String, null: false, description: 'Name of the organization responsible for the service'
+    field :url, String, null: false, description: 'URL of the website of the organization'
+
+    def name
+      'Wagner and Griffith laboratories'
+    end
+
+    def url
+      'https://dgidb.org/about#contact'
+    end
+  end
+end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -13,6 +13,8 @@ module Types
     field :categories, resolver: Resolvers::Categories
     field :interaction_claim_types, resolver: Resolvers::InteractionClaimTypes
 
+    field :dgidb_meta, Types::MetaType, null: false
+
     field :drug_suggestions, [Types::DrugSuggestionType], null: true do
       description "A searchable drug name or alias that can be completed from the supplied term"
       argument :term, String, required: true
@@ -330,6 +332,10 @@ module Types
 
     def publication(id:)
       Publication.find_by(id: id)
+    end
+
+    def dgidb_meta
+      {}
     end
   end
 end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -13,7 +13,7 @@ module Types
     field :categories, resolver: Resolvers::Categories
     field :interaction_claim_types, resolver: Resolvers::InteractionClaimTypes
 
-    field :dgidb_meta, Types::MetaType, null: false
+    field :service_info, Types::MetaType, null: false
 
     field :drug_suggestions, [Types::DrugSuggestionType], null: true do
       description "A searchable drug name or alias that can be completed from the supplied term"
@@ -334,7 +334,7 @@ module Types
       Publication.find_by(id: id)
     end
 
-    def dgidb_meta
+    def service_info
       {}
     end
   end

--- a/server/app/graphql/types/service_type.rb
+++ b/server/app/graphql/types/service_type.rb
@@ -1,0 +1,19 @@
+module Types
+  class ServiceType < Types::BaseObject
+    field :group, String, null: false, description: 'Namespace in reverse domain name format.'
+    field :artifact, String, null: false, description: 'Name of the API or GA4GH specification implemented.'
+    field :version, String, null: false, description: 'API Version (semantic)'
+
+    def group
+      'org.dgidb'
+    end
+
+    def artifact
+      'DGIdb GraphQL'
+    end
+
+    def version
+      GithubRelease.current&.dig("tag_name")
+    end
+  end
+end

--- a/server/app/models/github_release.rb
+++ b/server/app/models/github_release.rb
@@ -1,0 +1,18 @@
+class GithubRelease
+  def self.current
+    Rails.cache.fetch("current_github_release", expires_in: 12.hours) do
+      fetch_release
+    end
+  end
+
+  private
+  def self.fetch_release
+    uri = URI.parse('https://api.github.com/repos/dgidb/dgidb-v5/releases?per_page=1')
+    resp = Net::HTTP.get_response(uri)
+    if resp.code == '200'
+      JSON.parse(resp.body).first
+    else
+      nil
+    end
+  end
+end

--- a/server/config/initializers/dataset_version.rb
+++ b/server/config/initializers/dataset_version.rb
@@ -1,0 +1,8 @@
+file = File.join(Rails.root, 'data_version.yml')
+data = YAML.load_file(file)
+
+DATA_VERSION = data.dig('version')
+
+if DATA_VERSION.nil?
+  raise StandardError.new("Missing or malformed data_version.yml. Expect file at Rails.root with a version: key")
+end

--- a/server/data_version.yml
+++ b/server/data_version.yml
@@ -1,0 +1,1 @@
+version: Dec-2023


### PR DESCRIPTION
This adds an initializer in `config/initializers` that will run at boot. It expects to find a `data_version.yml` at the root dir of the application. That file should contain a key `version` containing the current data version.

This will be loaded into a constant.

When generating a new data release, you will need to remember to update this value (so, if there are docs for the process somewhere, may be good to add this step to them). Its manual for now, but as we automate the data generation process, we should automate this too.

Additionally, I have added a top level `serviceInfo` query to the API containing all the fields needed for the [GA4GH Service discovery spec](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/develop/service-info.yaml). Though the query obviously looks different given it is GraphQL rather than REST, the response should be compliant with their schema.

`updated_at` and `version` information for this is pulled live from GitHub. (`dataVersion` is still handled as described above)

The query
```gql
{
  serviceInfo {
    id
    name
    type {
      group
      artifact
      version
    }
    description
    organization {
      name
      url
    }
    contactUrl
    documentationUrl
    createdAt
    updatedAt
    environment
    version
    dataVersion
  }
}

```
Will yield
```json
{
  "data": {
    "serviceInfo": {
      "id": "org.dgidb.graphql",
      "name": "DGIdb",
      "type": {
        "group": "org.dgidb",
        "artifact": "DGIdb GraphQL",
        "version": "v.5.0.4"
      },
      "description": "An open-source search engine for drug-gene interactions and the druggable genome.",
      "organization": {
        "name": "Wagner and Griffith laboratories",
        "url": "https://dgidb.org/about#contact"
      },
      "contactUrl": "mailto:help@dgidb.org",
      "documentationUrl": "https://dgidb.org/api/graphiql",
      "createdAt": "2023-10-20T08:51:00-05:00",
      "updatedAt": "2024-01-30T18:04:04+00:00",
      "environment": "development",
      "version": "v.5.0.4",
      "dataVersion": "Dec-2023"
    }
  }
}
```

closes #481 