### PR TITLE
added row for Dec 2023 dumps

### DIFF
--- a/client/src/pages/Downloads/Files/Files.tsx
+++ b/client/src/pages/Downloads/Files/Files.tsx
@@ -25,6 +25,7 @@ function getDataObj(date: string) {
 
 const rows = [
   getDataObj('latest'),
+  getDataObj('2023-Dec'),
   getDataObj('2022-Feb'),
   getDataObj('2021-May'),
   getDataObj('2021-Jan'),


### PR DESCRIPTION
Adds a new row to the downloads table for the last Dec 2023 dumps. New TSVs have been provided to @acoffman that will replace the latest row, and what was in the latest row previously will go to the new Dec 2023 row.