### PR TITLE
build: remove some unused rails boilerplate/imports

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -4,22 +4,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "~>3.1.0"
 gem "rack-cors"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem "rails", "~> 6.1.3", ">= 6.1.3.1"
 gem "pg", "~>1.2.3"
-# Use Puma as the app server
-gem "puma" #, '~> 5.0', '>= 5.6.4'
+gem "puma"
 gem "rufo"
-
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
 
 gem "graphql", "~> 1.12.15"
 gem "graphql-batch", "~> 0.4.3"
@@ -32,10 +20,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 # Background job processing
 gem 'sidekiq', '~> 7.1.2'
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
-
-# Security vulnerability stuff
+# versions pinned for security vulnerability reasons
 gem "actionpack", ">= 6.1.4.6"
 gem "activestorage", ">= 6.1.4.7"
 gem "nokogiri", ">= 1.13.2"
@@ -53,12 +38,11 @@ gem "net-smtp", require: false
 gem "net-imap", require: false
 gem "net-pop", require: false
 
-#required for ssh tasks
+# required for ssh tasks
 gem 'ed25519'
 gem 'bcrypt_pbkdf'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails", "~> 5.1"
   gem "factory_bot", "~> 6.2"
@@ -66,7 +50,6 @@ end
 
 group :development do
   gem "listen", "~> 3.3"
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "rack-mini-profiler"
 

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
       net-protocol
     net-ssh (7.1.0)
     nio4r (2.5.9)
+    nokogiri (1.15.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
@@ -222,6 +224,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
     sshkit (1.21.4)
@@ -240,6 +243,7 @@ GEM
     zlib (3.0.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/server/app/mailers/application_mailer.rb
+++ b/server/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/server/config/application.rb
+++ b/server/config/application.rb
@@ -7,13 +7,9 @@ require "active_job/railtie"
 require "active_record/railtie"
 require "active_storage/engine"
 require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_mailbox/engine"
-require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
-require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/server/config/environments/development.rb
+++ b/server/config/environments/development.rb
@@ -31,9 +31,9 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/server/config/environments/production.rb
+++ b/server/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "dgidb_production"
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/server/config/environments/test.rb
+++ b/server/config/environments/test.rb
@@ -36,12 +36,12 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
Not sure how kosher this is, but I went ahead and removed some boilerplate comments/imports that we didn't appear to be using. Let me know if anything looks problematic.