### PR TITLE
fix: use latest GO api changes

### DIFF
--- a/server/lib/genome/importers/api_importers/go/api_client.rb
+++ b/server/lib/genome/importers/api_importers/go/api_client.rb
@@ -15,7 +15,6 @@ module Genome; module Importers; module ApiImporters; module Go;
     end
 
     def make_get_request(uri)
-      puts uri
       res = Net::HTTP.get_response(uri)
       raise StandardError, 'Request Failed!' unless res.code == '200'
 

--- a/server/lib/genome/importers/api_importers/go/api_client.rb
+++ b/server/lib/genome/importers/api_importers/go/api_client.rb
@@ -15,6 +15,7 @@ module Genome; module Importers; module ApiImporters; module Go;
     end
 
     def make_get_request(uri)
+      puts uri
       res = Net::HTTP.get_response(uri)
       raise StandardError, 'Request Failed!' unless res.code == '200'
 
@@ -22,7 +23,7 @@ module Genome; module Importers; module ApiImporters; module Go;
     end
 
     def gene_lookup_base_url(id)
-      "https://api.geneontology.org/api/bioentity/function/%22GO:#{id}%22"
+      "https://api.geneontology.org/api/bioentity/function/GO:#{id}"
     end
 
     def params(start, rows)

--- a/server/lib/genome/importers/api_importers/go/importer.rb
+++ b/server/lib/genome/importers/api_importers/go/importer.rb
@@ -36,13 +36,13 @@ module Genome; module Importers; module ApiImporters; module Go;
       categories.each do |category, go_id|
         start = 0
         rows = 500
-        genes = api_client.genes_for_go_id(go_id, start, rows)
-        while genes.count.positive? do
+        loop do
+          genes = api_client.genes_for_go_id(go_id, start, rows)
           genes.each do |gene|
             create_gene_claim_for_entry(gene, category) if gene['taxon_label'] == 'Homo sapiens'
           end
+          break if genes.count < rows
           start += rows
-          genes = api_client.genes_for_go_id(go_id, start, rows)
         end
       end
     end


### PR DESCRIPTION
Two weird changes seem to have happened with the GO API:

1) it doesn't like the quotes in the URL anymore
2) if pages are exhausted, it gives a 404 rather than returning an empty array

this PR adds fixes for both