### PR TITLE
feat: rake task to load DB from local file

### DIFF
--- a/server/lib/tasks/db_bootstrapping.rake
+++ b/server/lib/tasks/db_bootstrapping.rake
@@ -25,11 +25,11 @@ namespace :dgidb do
       if File.exist?( '/Applications/Postgres.app' )
         puts 'Using Postgres.app'
         ENV['PATH'] = "/Applications/Postgres.app/Contents/Versions/latest/bin:#{ENV['PATH']}"
-        return
+        next
       elsif File.exist?('/opt/homebrew/bin/psql')
         puts 'Using Hombrew-installed psql'
         ENV['PATH'] = "/opt/homebrew/bin/:#{ENV['PATH']}"
-        return
+        next
       end
     end
     puts 'Warning: unable to ensure psql is available on $PATH'
@@ -49,13 +49,6 @@ namespace :dgidb do
     raise 'You must supply a path to a DB dump' unless args[:db_dump]
 
     system "psql -h #{host} -d #{database_name} -f #{args[:db_dump]}"
-    Rails.cache.clear
-  end
-
-  desc 'load the latest available remote db dump and schema into the local db, blowing away what is currently there'
-  task load_from_remote: ['setup_path', 'db:drop', 'db:create', 'db:structure:load'] do
-    download_data_dump(data_file)
-    system "psql -h #{host} -d #{database_name} -f #{data_file}"
     Rails.cache.clear
   end
 end

--- a/server/lib/tasks/db_bootstrapping.rake
+++ b/server/lib/tasks/db_bootstrapping.rake
@@ -26,7 +26,7 @@ namespace :dgidb do
         puts 'Using Postgres.app'
         ENV['PATH'] = "/Applications/Postgres.app/Contents/Versions/latest/bin:#{ENV['PATH']}"
         return
-      if File.exist?('/opt/homebrew/bin/psql')
+      elsif File.exist?('/opt/homebrew/bin/psql')
         puts 'Using Hombrew-installed psql'
         ENV['PATH'] = "/opt/homebrew/bin/:#{ENV['PATH']}"
         return
@@ -49,6 +49,7 @@ namespace :dgidb do
     raise 'You must supply a path to a DB dump' unless args[:db_dump]
 
     system "psql -h #{host} -d #{database_name} -f #{args[:db_dump]}"
+    Rails.cache.clear
   end
 
   desc 'load the latest available remote db dump and schema into the local db, blowing away what is currently there'

--- a/server/lib/tasks/db_bootstrapping.rake
+++ b/server/lib/tasks/db_bootstrapping.rake
@@ -25,11 +25,14 @@ namespace :dgidb do
       if File.exist?( '/Applications/Postgres.app' )
         puts 'Using Postgres.app'
         ENV['PATH'] = "/Applications/Postgres.app/Contents/Versions/latest/bin:#{ENV['PATH']}"
-      elsif File.exist?('/opt/homebrew/bin/psql')
+        return
+      if File.exist?('/opt/homebrew/bin/psql')
         puts 'Using Hombrew-installed psql'
         ENV['PATH'] = "/opt/homebrew/bin/:#{ENV['PATH']}"
+        return
       end
     end
+    puts 'Warning: unable to ensure psql is available on $PATH'
   end
 
   desc 'create a dump of the current local database'

--- a/server/lib/utils/snapshot_helpers.rb
+++ b/server/lib/utils/snapshot_helpers.rb
@@ -48,13 +48,6 @@ module Utils; module SnapshotHelpers
     system_or_die("git submodule update --init data")
   end
 
-  def download_data_dump(destination)
-    unless Dir.exist? 'data'
-      Dir.mkdir('data')
-    end
-    system_or_die("wget -O #{destination} https://nch-igm-wagner-lab-public.s3.us-east-2.amazonaws.com/dgidb_v5_latest.sql")
-  end
-
   private
 
   def system_or_die(syscall)


### PR DESCRIPTION
* add a rake task to load DB w/ local sql dump
* remove rake task to download from remote. It depends on a static s3://<wagner bucket>/dgidb/dgidb_latest.sql URI and I'm not really happy with maintaining that. I'd rather have a better way of dynamically pointing to the latest-dated dump. Also, I thought some of the data was supposed to be private but I could be wrong.
* slightly reconfigure the section for psql executable injection into the PATH. Drop macports support. Add homebrew (ARM64) support.