### PR TITLE
test: add basic API tests

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails", "~> 5.1"
   gem "factory_bot", "~> 6.2"
+  gem "capybara"
 end
 
 group :development do

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     base64 (0.2.0)
@@ -82,6 +84,15 @@ GEM
     capistrano-rbenv (2.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -121,6 +132,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
@@ -151,6 +163,7 @@ GEM
     ostruct (0.6.0)
     pg (1.2.3)
     promise.rb (0.7.4)
+    public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -195,6 +208,7 @@ GEM
       ffi (~> 1.0)
     redis-client (0.22.2)
       connection_pool
+    regexp_parser (2.9.3)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -249,6 +263,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.18)
     zlib (3.1.1)
 
@@ -265,6 +281,7 @@ DEPENDENCIES
   capistrano
   capistrano-rails
   capistrano-rbenv
+  capybara
   ed25519
   factory_bot (~> 6.2)
   graphiql-rails (~> 1.7.0)

--- a/server/app/controllers/concerns/analytics.rb
+++ b/server/app/controllers/concerns/analytics.rb
@@ -2,7 +2,7 @@ module Analytics
   extend ActiveSupport::Concern
 
   def get_trace_mode(request)
-    return unless Rails.env.production?
+    return unless Rails.application.config.analytics_enabled
 
     query_types = %w[search-genes search-drugs]
     if request.headers['dgidb-client-name'] == 'dgidb-frontend'

--- a/server/config/environments/development.rb
+++ b/server/config/environments/development.rb
@@ -63,4 +63,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Disable analytics by default
+  config.analytics_enabled = false
 end

--- a/server/config/environments/production.rb
+++ b/server/config/environments/production.rb
@@ -113,4 +113,7 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # enable analytics
+  config.analytics_enabled = true
 end

--- a/server/config/environments/test.rb
+++ b/server/config/environments/test.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Disable analytics by default
+  config.analytics_enabled = false
 end

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -1,0 +1,34 @@
+# This configuration file will be evaluated by Puma. The top-level methods that
+# are invoked here are part of Puma's configuration DSL. For more information
+# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+
+# Puma starts a configurable number of processes (workers) and each process
+# serves each request in a thread from an internal thread pool.
+#
+# The ideal number of threads per worker depends both on how much time the
+# application spends waiting for IO operations and on how much you wish to
+# to prioritize throughput over latency.
+#
+# As a rule of thumb, increasing the number of threads will increase how much
+# traffic a given process can handle (throughput), but due to CRuby's
+# Global VM Lock (GVL) it has diminishing returns and will degrade the
+# response time (latency) of the application.
+#
+# The default is set to 3 threads as it's deemed a decent compromise between
+# throughput and latency for the average Rails application.
+#
+# Any libraries that use a connection pool or another resource pool should
+# be configured to provide at least as many connections as the number of
+# threads. This includes Active Record's `pool` parameter in `database.yml`.
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+port ENV.fetch("PORT", 3000)
+
+# Allow puma to be restarted by `bin/rails restart` command.
+plugin :tmp_restart
+
+# Specify the PID file. Defaults to tmp/pids/server.pid in development.
+# In other environments, only set the PID file if requested.
+pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/server/spec/rails_helper.rb
+++ b/server/spec/rails_helper.rb
@@ -10,6 +10,8 @@ require 'rspec/rails'
 require 'support/factory_bot'
 require 'support/graphql'
 
+require 'capybara/rails'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/server/spec/requests/graphql_spec.rb
+++ b/server/spec/requests/graphql_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'GraphQL Endpoint', type: :request do
+  let(:graphql_endpoint) { '/api/graphql' }
+
+  around do |test_case|
+    Rails.application.config.analytics_enabled = true
+    test_case.run
+    Rails.application.config.analytics_enabled = false
+  end
+
+  schema_query = {
+    query: <<-GRAPHQL
+      {
+        __schema {
+          queryType {
+            name
+          }
+        }
+      }
+    GRAPHQL
+  }
+
+  simple_query = {
+    query: <<-GRAPHQL
+    {
+      drugs(first: 1) {
+        edges {
+          node {
+            name
+          }
+        }
+      }
+    }
+    GRAPHQL
+  }
+
+  it 'responds with 200 for a schema query from the frontend' do
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'dgidb-client-name' => 'dgidb-frontend'
+    }
+
+    post(graphql_endpoint, params: schema_query.to_json, headers:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
+
+  it 'responds with 200 for a simple query from the frontend' do
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'dgidb-client-name' => 'dgidb-frontend'
+    }
+
+    post(graphql_endpoint, params: simple_query.to_json, headers:)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
+
+  it 'responds with 200 for a schema query from the API' do
+    post graphql_endpoint, params: schema_query.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
+
+  it 'responds with 200 for a simple query from the API' do
+    post graphql_endpoint, params: simple_query.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
+end


### PR DESCRIPTION
Add simple tests for successful server response to requests made to the GraphQL API.

Slightly modified tracer configs to use a Ruby environment config rather than check directly for the environment. This value is temporarily changed in the request test but otherwise unaltered.