### PR TITLE
feat: use concept IDs in grouping first

### DIFF
--- a/server/lib/genome/groupers/base.rb
+++ b/server/lib/genome/groupers/base.rb
@@ -2,9 +2,32 @@ module Genome
   module Groupers
     # Provides some shared methods for groupers, shouldn't be directly instantiated.
     class Base < Genome::DataImporter
+
+      def initialize
+        @term_to_normalized_id = {}
+        @sources = {}
+      end
+
+      private
+
+      def print_grouping_message(claims, source_id)
+        if source_id.nil?
+          puts "Grouping #{claims.length} ungrouped #{@entity_type} claims"
+        else
+          begin
+            source = Source.find(source_id)
+          rescue ActiveRecord::RecordNotFound
+            puts 'Unrecognized source ID provided'
+            return
+          end
+          source_name = source.source_db_name
+          puts "Grouping #{claims.length} ungrouped #{@entity_type} claims from #{source_name}"
+        end
+      end
+
       # Sends an empty query to concept normalizer to retrieve the service's version
       def retrieve_normalizer_version
-        response = retrieve_normalizer_response('')
+        response = retrieve_normalized_concept_id('')
         response['service_meta_']['version']
       end
 
@@ -30,10 +53,37 @@ module Genome
         body['source_matches'].transform_values { |value| value['source_meta_'] }
       end
 
-      # Normalize claim terms
-      # If the primary term normalizes successfully, go with that. Otherwise, iterate
-      # through claims and tally all 'votes' for normalized concepts with the highest match
-      # type. For example:
+      # Construct individual groups for normalizing terms
+      # Returns a sorted array of normalizable concept IDs, a primary name if given,
+      # and aliases that aren't otherwise known to normalize (e.g. other names, trade names,
+      # concept IDs from niche namespaces)
+      def get_claim_search_groups(claim, claim_aliases)
+        groups = { 'concept_ids' => [], 'name' => nil, 'aliases' => [] }
+
+        concept_ids = []
+        if normalizable_ids.include? claim.nomenclature
+          concept_ids << [claim.name, claim.nomenclature]
+        else
+          groups['name'] = claim.name
+        end
+
+        claim_aliases.each do |ca|
+          if normalizable_ids.include? ca.nomenclature
+            concept_ids << [ca.alias, ca.nomenclature]
+          else
+            groups['aliases'] << ca.alias
+          end
+        end
+
+        groups['concept_ids'] = concept_ids
+                                .sort_by! { |_, nomenclature| normalizable_ids.index(nomenclature) || Float::INFINITY }
+                                .map { |concept_id| concept_id[0] }
+        groups
+      end
+
+      # Try to determine grouping of a claim based on consensus of its aliases.
+      # Iterate through aliases and tally all 'votes' for normalized concepts with the
+      # highest match type. For example:
       # 1) if a gene has three aliases, and two match as `ALIASES` to gene A and the third
       # matches as an `ALIAS` to gene B, we pick gene A
       # 2) if a gene has five aliases, and one alias matches as a `LABEL` to gene A, but
@@ -44,80 +94,116 @@ module Genome
       # 4) if a gene has four aliases, and two match as `LABELS` to different genes, and
       # the other two match as `ALIASES` to two different genes, we can't break any ties.
       # So, we just take the first `LABEL` match we saw (arbitrarily).
-      def normalize_claim(primary_term, claim_aliases)
-        primary_term_upcase = primary_term.upcase
-        return @term_to_match_dict[primary_term_upcase] if key_non_nil_match(primary_term_upcase)
+      # Experimentally, these lower conditions happen ~not at all, but we want to have
+      # them to fall back on just in case.
+      def normalize_claim_by_aliases(claim_aliases)
+        alias_responses = {}
+        match_votes = {
+          100 => Hash.new(0),
+          80 => Hash.new(0),
+          60 => Hash.new(0)
+        }
+        claim_aliases.each do |claim_alias|
+          response = retrieve_normalizer_response(claim_alias)
+          match_type = response['match_type']
+          next if response.nil? || match_type.zero?
 
-        response = retrieve_normalizer_response(primary_term)
-        if response.nil? || response['match_type'].zero?
-          claim_responses = Hash.new
-          match_votes = {
-            100 => Hash.new(0),
-            80 => Hash.new(0),
-            60 => Hash.new(0),
-          }
-          claim_aliases.each do |claim_alias|
-            response = retrieve_normalizer_response(claim_alias.alias)
-            match_type = response['match_type']
-            if !response.nil? && match_type > 0
-              concept_id = response['normalized_id']
-              if !claim_responses.key?(concept_id)
-                claim_responses[concept_id] = response
-              end
-              match_votes[match_type][concept_id] += 1
-            end
-          end
+          concept_id = response[@entity_type]['id']
+          alias_responses[concept_id] = response unless alias_responses.key?(concept_id)
+          match_votes[match_type][concept_id] += 1
+        end
 
-          # tally votes
-          best_default = nil
-          best_match = nil
-          match_votes.keys.sort.reverse.each do |match_type|
-            next if !best_match.nil?
-            most_votes = match_votes[match_type].values.max
-            next if most_votes.nil?
-            highest_vote_getters = match_votes[match_type].select {|_key, value| value == most_votes}.keys
-            if highest_vote_getters.length == 1
-              best_match = highest_vote_getters[0]
-            elsif highest_vote_getters.length > 1 && best_default.nil?
-              best_default = highest_vote_getters[0]
-            end
-          end
-          if !best_match.nil?
-            response = claim_responses[best_match]
-          elsif !best_default.nil?
-            response = claim_responses[best_default]
-          else
-            response = nil
+        # tally votes
+        best_default = nil
+        best_match = nil
+        match_votes.keys.sort.reverse.each do |match_type|
+          next unless best_match.nil?
+
+          most_votes = match_votes[match_type].values.max
+          next if most_votes.nil?
+
+          highest_vote_getters = match_votes[match_type].select { |_key, value| value == most_votes }.keys
+          if highest_vote_getters.length == 1
+            best_match = highest_vote_getters[0]
+          elsif highest_vote_getters.length > 1 && best_default.nil?
+            best_default = highest_vote_getters[0]
           end
         end
-        response
+
+        if !best_match.nil?
+          alias_responses[best_match]
+        elsif !best_default.nil?
+          alias_responses[best_default]
+        end
+      end
+
+      # Normalize claim based on name/alias terms. Return normalized concept ID
+      # under which the claim should be grouped.
+      # First, normalize by concept IDs from known namespaces. Go with the first one
+      # to return a match.
+      # If none match, then try to normalize by the claim name, if it wasn't included
+      # in the search above.
+      # Failing that, try to match based on consensus of other alias terms.
+      # See `normalize_claim_by_aliases()`.
+      def normalize_claim(claim, claim_aliases)
+        term_search_groups = get_claim_search_groups(claim, claim_aliases)
+
+        # try concept IDs. take first successful match
+        term_search_groups['concept_ids'].each do |concept_id|
+          normalized_id = retrieve_normalized_id(concept_id)
+          return normalized_id unless normalized_id.nil?
+        end
+
+        # try claim name if it wasn't in a set of recognized concept ID nomenclatures
+        unless term_search_groups['name'].nil?
+          normalized_id = retrieve_normalized_id(term_search_groups['name'])
+          return normalized_id unless normalized_id.nil?
+        end
+
+        normalize_claim_by_aliases(term_search_groups['aliases'])
       end
 
       def get_concept_id(response)
-        response['normalized_id'] unless response['match_type'].zero?
+        response[@normalizer_entity_type]['id'].split('.', 3)[2] unless response['match_type'].zero?
       end
 
-      def retrieve_extension(descriptor, type, default = nil)
-        unless descriptor.fetch('extensions').blank?
-          descriptor['extensions'].each do |extension|
+      def get_normalized_name(response)
+        if response[@normalizer_entity_type]['name'].nil? || response[@normalizer_entity_type]['name'].blank?
+          get_concept_id(response)
+        else
+          response[@normalizer_entity_type]['name']
+        end
+      end
+
+      def retrieve_normalized_id(term)
+        term_upcased = term.upcase
+        return @term_to_normalized_id[term_upcased] if @term_to_normalized_id.key?(term_upcased)
+
+        get_concept_id(retrieve_normalizer_response(term_upcased))
+      end
+
+      def retrieve_normalizer_response(term)
+        term_upcased = term.upcase
+        body = fetch_json_response("#{@normalizer_host}normalize?q=#{CGI.escape(term_upcased)}")
+        @term_to_normalized_id[term_upcased] = get_concept_id(body) unless term_upcased == ''
+        body
+      end
+
+      def key_non_nil_match(term)
+        true if @term_to_match_dict.key?(term) && !@term_to_match_dict[term].nil?
+      end
+
+      def retrieve_extension(normalizer_response, type, default = nil)
+        extensions = normalizer_response[@normalizer_entity_type].fetch('extensions')
+        unless extensions.blank?
+          extensions.each do |extension|
             return extension['value'] if extension['name'] == type
           end
         end
         default
       end
 
-      def retrieve_normalizer_response(term)
-        body = fetch_json_response("#{@normalizer_host}normalize?q=#{CGI.escape(term)}")
-        @term_to_match_dict[term.upcase] = get_concept_id(body) unless term == '' || body.nil?
-
-        body
-      end
-
-      def key_non_nil_match(term)
-        return true if @term_to_match_dict.key?(term) && !@term_to_match_dict[term].nil?
-      end
-
-      def retrieve_normalizer_data(term)
+      def retrieve_grouper_records(term)
         body = fetch_json_response("#{@normalizer_host}normalize_unmerged?q=#{CGI.escape(term)}")
         body['source_matches']
       end

--- a/server/lib/genome/groupers/drug_grouper.rb
+++ b/server/lib/genome/groupers/drug_grouper.rb
@@ -4,51 +4,132 @@ module Genome
       attr_reader :term_to_match_dict
 
       def initialize
+        super
         url_base = ENV['THERAPY_HOSTNAME'] || 'http://localhost:8000'
-        if !url_base.ends_with? "/"
-          url_base += "/"
-        end
+        url_base += '/' unless url_base.ends_with? '/'
+
+        @entity_type = 'drug'
+        @normalizer_entity_type = 'therapy'
         @normalizer_host = "#{url_base}therapy/"
-
-        @term_to_match_dict = {}
-
-        @sources = {}
       end
 
-      def run(source_id = nil)
+      def group_claims(source_id = nil)
         claims = DrugClaim.eager_load(:drug_claim_aliases, :drug_claim_attributes).where(drug_id: nil)
         claims = claims.where(source_id: source_id) unless source_id.nil?
-        if source_id.nil?
-          puts "Grouping #{claims.length} ungrouped drug claims"
-        else
-          begin
-            source = Source.find(source_id)
-          rescue ActiveRecord::RecordNotFound
-            puts 'Unrecognized source ID provided'
-            return
-          end
-          source_name = source.source_db_name
-          puts "Grouping #{claims.length} ungrouped drug claims from #{source_name}"
-        end
 
+        print_grouping_message(claims, source_id)
         create_sources
-
 
         pbar = ProgressBar.create(title: 'Grouping drugs', total: claims.size, format: "%t: %p%% %a |%B|")
         claims.each do |drug_claim|
-          normalized_drug = normalize_claim(drug_claim.name, drug_claim.drug_claim_aliases)
-          next if normalized_drug.nil?
-
-          if normalized_drug.is_a? String
-            normalized_id = normalized_drug
-          else
-            normalized_id = normalized_drug['normalized_id']
-            create_new_drug(normalized_drug['therapeutic_agent'], normalized_id) if Drug.find_by(concept_id: normalized_id).nil?
-          end
-          add_claim_to_drug(drug_claim, normalized_id)
+          group_drug_claim(drug_claim)
 
           pbar.progress += 1
         end
+      end
+
+      private
+
+      def find_drug_attribute(drug_claim_attribute)
+        drug_attribute = DrugAttribute.where(
+          'upper(name) = ? and upper(value) = ?',
+          drug_claim_attribute.name.upcase,
+          drug_claim_attribute.value.upcase
+        ).first
+        if drug_attribute.nil?
+          drug_attribute = DrugAttribute.where(
+            'lower(name) = ? and lower(value) = ?',
+            drug_claim_attribute.name.downcase,
+            drug_claim_attribute.value.downcase
+          ).first
+        end
+        drug_attribute
+      end
+
+      def add_claim_attributes(claim, drug)
+        drug_attributes = drug.drug_attributes.pluck(:name, :value)
+                              .map { |drug_attribute| drug_attribute.map(&:upcase) }
+                              .to_set
+        claim.drug_claim_attributes.each do |dca|
+          if drug_attributes.member? [dca.name.upcase, dca.value.upcase]
+            drug_attribute = find_drug_attribute(dca)
+          else
+            drug_attribute = DrugAttribute.create(
+              name: dca.name,
+              value: dca.value,
+              drug: drug
+            )
+          end
+          unless drug_attribute.sources.member? claim.source
+            drug_attribute.sources << claim.source
+            drug_attribute.save
+          end
+        end
+      end
+
+      def add_claim_aliases(claim, drug)
+        drug_aliases = drug.drug_aliases.pluck(:alias).map(&:upcase).to_set
+        drug_claim_aliases = claim.drug_claim_aliases.pluck(:alias)
+        unless claim.name == drug.name || claim.name == drug.concept_id || claim.source.source_db_name == 'Drugs@FDA'
+          drug_claim_aliases.append(claim.name)
+        end
+        drug_claim_aliases.map(&:upcase).to_set.each do |claim_alias|
+          if (drug_aliases.member? claim_alias) || claim_alias == drug.name || claim_alias == drug.concept_id.upcase
+            next
+          end
+
+          DrugAlias.create(alias: claim_alias, drug: drug)
+        end
+      end
+
+      def add_claim_approval_ratings(claim, drug)
+        claim.drug_claim_approval_ratings.each do |rating|
+          DrugApprovalRating.where(
+            rating: rating.rating,
+            drug_id: drug.id,
+            source_id: claim.source_id
+          ).first_or_create
+        end
+      end
+
+      def add_application(claim, drug)
+        DrugApplication.create(app_no: claim.name, drug: drug)
+      end
+
+      def add_claim_to_drug(claim, drug_concept_id)
+        drug = Drug.find_by(concept_id: drug_concept_id)
+        return if drug.nil?
+
+        claim.drug_id = drug.id
+        claim.save
+        add_claim_attributes(claim, drug)
+        add_claim_aliases(claim, drug)
+        add_claim_approval_ratings(claim, drug)
+        add_application(claim, drug) if claim.source.source_db_name == 'Drugs@FDA'
+      end
+
+      def group_drug_claim(drug_claim)
+        normalized_id = normalize_claim(drug_claim, drug_claim.drug_claim_aliases)
+        return if normalized_id.nil?
+
+        create_new_drug(normalized_id) if Drug.find_by(concept_id: normalized_id).nil?
+        add_claim_to_drug(drug_claim, normalized_id)
+      end
+
+      def normalizable_ids
+        [
+          DrugNomenclature::RXNORM_ID,
+          DrugNomenclature::NCIT_ID,
+          DrugNomenclature::DRUGBANK_ID,
+          DrugNomenclature::CHEMBL_ID,
+          DrugNomenclature::PUBCHEM_COMPOUND_ID,
+          DrugNomenclature::HEMONC_ID,
+          DrugNomenclature::CHEMIDPLUS_ID,
+          DrugNomenclature::WIKIDATA_ID,
+          DrugNomenclature::GTOP_LIGAND_ID,
+          DrugNomenclature::PUBCHEM_SUBSTANCE_ID,
+          DrugNomenclature::DRUGSATFDA_ID
+        ]
       end
 
       def create_sources
@@ -207,18 +288,13 @@ module Genome
           }
           rating = lookup[value]
         end
-        DrugClaimApprovalRating.where(
-          rating: rating,
-          drug_claim_id: claim.id
-        ).first_or_create unless rating.nil?
+        DrugClaimApprovalRating.where(rating: rating, drug_claim_id: claim.id).first_or_create unless rating.nil?
       end
 
       def add_grouper_claim_attributes(claim, record)
         approval_ratings = record.fetch('approval_ratings', [])
-        unless approval_ratings.nil?
-          approval_ratings.to_set.each do |rating|
-            add_grouper_claim_approval_rating(claim, rating)
-          end
+        approval_ratings&.to_set&.each do |rating|
+          add_grouper_claim_approval_rating(claim, rating)
         end
 
         record.fetch('approval_year', []).to_set.each do |year|
@@ -228,7 +304,7 @@ module Genome
         indications = record.fetch('has_indication')
         return unless indications.nil?
 
-        indications.filter_map { |ind| ind['label'].upcase unless ind['label'].nil? }.to_set.each do |indication|
+        indications.filter_map { |ind| ind['label']&.upcase }.to_set.each do |indication|
           DrugClaimAttribute.create(name: DrugAttributeName::INDICATION, value: indication, drug_claim_id: claim.id)
         end
       end
@@ -256,28 +332,23 @@ module Genome
             produce_concept_id_nomenclature(record['concept_id'])
           )
         end
-
         unless record['label'].nil? || record['label'] == claim_name
           add_grouper_claim_alias(record['label'], claim_name, claim.id, DrugNomenclature::PRIMARY_NAME)
         end
-
         prune_alias_list(record.fetch('aliases', [])).each do |value|
           add_grouper_claim_alias(value, claim_name, claim.id, DrugNomenclature::ALIAS)
         end
-
         prune_alias_list(record.fetch('trade_names', [])).each do |value|
           add_grouper_claim_alias(value, claim_name, claim.id, DrugNomenclature::TRADE_NAME)
         end
-
         prune_alias_list(record.fetch('xrefs', [])).each do |value|
           add_grouper_claim_alias(value, claim_name, claim.id, DrugNomenclature::XREF)
         end
       end
 
-      def add_grouper_data(drug, drug_response, concept_id)
-        drug_data = retrieve_normalizer_data(concept_id)
-
-        drug_data.each do |source_name, source_data|
+      def add_grouper_data(drug, concept_id)
+        retrieve_grouper_records(concept_id).each do |source_name, source_data|
+          # skip sources that we already import in DGIdb
           next if %w[DrugBank ChEMBL GuideToPHARMACOLOGY].include?(source_name)
 
           source = @sources[source_name.to_sym]
@@ -291,90 +362,12 @@ module Genome
         end
       end
 
-      def create_new_drug(drug_response, concept_id)
-        name = if drug_response['label'].nil? || drug_response['label'].blank?
-                 concept_id
-               else
-                 drug_response['label']
-               end
+      def create_new_drug(concept_id)
+        drug_response = retrieve_normalizer_response(concept_id)
+        name = get_normalized_name(drug_response)
         drug = Drug.where(concept_id: concept_id, name: name.upcase).first_or_create
 
-        add_grouper_data(drug, drug_response, concept_id)
-      end
-
-      def find_drug_attribute(drug_claim_attribute)
-        drug_attribute = DrugAttribute.where(
-          'upper(name) = ? and upper(value) = ?',
-          drug_claim_attribute.name.upcase,
-          drug_claim_attribute.value.upcase
-        ).first
-        if drug_attribute.nil?
-          drug_attribute = DrugAttribute.where(
-            'lower(name) = ? and lower(value) = ?',
-            drug_claim_attribute.name.downcase,
-            drug_claim_attribute.value.downcase
-          ).first
-        end
-        drug_attribute
-      end
-
-      def add_claim_attributes(claim, drug)
-        drug_attributes = drug.drug_attributes.pluck(:name, :value)
-                              .map { |drug_attribute| drug_attribute.map(&:upcase) }
-                              .to_set
-        claim.drug_claim_attributes.each do |drug_claim_attribute|
-          if drug_attributes.member? [drug_claim_attribute.name.upcase, drug_claim_attribute.value.upcase]
-            drug_attribute = find_drug_attribute(drug_claim_attribute)
-          else
-            drug_attribute = DrugAttribute.create(
-              name: drug_claim_attribute.name,
-              value: drug_claim_attribute.value,
-              drug: drug
-            )
-          end
-          unless drug_attribute.sources.member? claim.source
-            drug_attribute.sources << claim.source
-            drug_attribute.save
-          end
-        end
-      end
-
-      def add_claim_approval_ratings(claim, drug)
-        claim.drug_claim_approval_ratings.each do |rating|
-          DrugApprovalRating.where(
-            rating: rating.rating,
-            drug_id: drug.id,
-            source_id: claim.source_id
-          ).first_or_create
-        end
-      end
-
-      def add_claim_aliases(claim, drug)
-        drug_aliases = drug.drug_aliases.pluck(:alias).map(&:upcase).to_set
-        drug_claim_aliases = claim.drug_claim_aliases.pluck(:alias)
-        unless claim.name == drug.name || claim.name == drug.concept_id || claim.source.source_db_name == 'Drugs@FDA'
-          drug_claim_aliases.append(claim.name)
-        end
-        drug_claim_aliases.map(&:upcase).to_set.each do |claim_alias|
-          next if drug_aliases.member? claim_alias || claim_alias == drug.name || claim_alias == drug.concept_id.upcase
-          DrugAlias.create(alias: claim_alias, drug: drug)
-        end
-      end
-
-      def add_application(claim, drug)
-        DrugApplication.create(app_no: claim.name, drug: drug)
-      end
-
-      def add_claim_to_drug(claim, drug_concept_id)
-        drug = Drug.find_by(concept_id: drug_concept_id)
-        return if drug.nil?
-
-        claim.drug_id = drug.id
-        claim.save
-        add_claim_attributes(claim, drug)
-        add_claim_aliases(claim, drug)
-        add_claim_approval_ratings(claim, drug)
-        add_application(claim, drug) if claim.source.source_db_name == 'Drugs@FDA'
+        add_grouper_data(drug, concept_id)
       end
     end
   end

--- a/server/lib/genome/groupers/gene_grouper.rb
+++ b/server/lib/genome/groupers/gene_grouper.rb
@@ -4,14 +4,13 @@ module Genome
       attr_reader :term_to_match_dict
 
       def initialize
+        super
         url_base = ENV['GENE_HOSTNAME'] || 'http://localhost:8000'
-        if !url_base.ends_with? "/"
-          url_base += "/"
-        end
-        @normalizer_host = "#{url_base}gene/"
+        url_base += '/' unless url_base.ends_with? '/'
 
-        @term_to_match_dict = {}
-        @sources = {}
+        @entity_type = 'gene'
+        @normalizer_entity_type = 'gene'
+        @normalizer_host = "#{url_base}gene/"
 
         @source_gene_type_names = {
           Ensembl: GeneAttributeName::ENSEMBL_TYPE,
@@ -20,40 +19,22 @@ module Genome
         }
       end
 
-      def run(source_id = nil)
+      def group_claims(source_id = nil)
         claims = GeneClaim.eager_load(:gene_claim_aliases, :gene_claim_attributes).where(gene_id: nil)
         claims = claims.where(source_id: source_id) unless source_id.nil?
-        if source_id.nil?
-          puts "Grouping #{claims.length} ungrouped gene claims"
-        else
-          begin
-            source = Source.find(source_id)
-          rescue ActiveRecord::RecordNotFound
-            puts 'Unrecognized source ID provided'
-            return
-          end
-          source_name = source.source_db_name
-          puts "Grouping #{claims.length} ungrouped gene claims from #{source_name}"
-        end
 
+        print_grouping_message(claims, source_id)
         create_sources
 
         pbar = ProgressBar.create(title: 'Grouping genes', total: claims.size, format: "%t: %p%% %a |%B|")
         claims.each do |gene_claim|
-          normalized_gene = normalize_claim(gene_claim.name, gene_claim.gene_claim_aliases)
-          next if normalized_gene.nil?
-
-          if normalized_gene.is_a? String
-            normalized_id = normalized_gene
-          else
-            normalized_id = normalized_gene['normalized_id']
-            create_new_gene(normalized_gene['gene'], normalized_id) if Gene.find_by(concept_id: normalized_id).nil?
-          end
-          add_claim_to_gene(gene_claim, normalized_id)
+          group_gene_claim(gene_claim)
 
           pbar.progress += 1
         end
       end
+
+      private
 
       def create_sources
         gene_source_type = SourceType.find_by(type: 'gene')
@@ -193,36 +174,6 @@ module Genome
         )
       end
 
-      def add_grouper_data(gene, descriptor, normalized_id)
-        gene_data = retrieve_normalizer_data(normalized_id)
-        gene_data.each do |source_name, source_data|
-          source = @sources[source_name.to_sym]
-
-          source_data['records'].each do |record|
-            claim = create_gene_claim(record, source)
-            add_grouper_claim_aliases(claim, record)
-            add_grouper_claim_attribute(claim, record)
-
-            add_claim_to_gene(claim, gene.concept_id)
-          end
-        end
-      end
-
-      def create_new_gene(gene_response, normalized_id)
-        name = if gene_response.fetch('label').blank?
-                 normalized_id
-               else
-                 gene_response['label']
-               end
-        gene = Gene.where(
-          concept_id: normalized_id,
-          name: name,
-          long_name: retrieve_extension(gene_response, 'approved_name')
-        ).first_or_create
-
-        add_grouper_data(gene, gene_response, normalized_id)
-      end
-
       def add_claim_attributes(claim, gene)
         gene_attributes = gene.gene_attributes.pluck(:name, :value)
                               .map { |gene_attribute| gene_attribute.map(&:upcase) }
@@ -294,6 +245,50 @@ module Genome
         add_claim_attributes(claim, gene)
         add_claim_categories(claim, gene)
         claim.save
+      end
+
+      def add_grouper_data(gene, normalized_id)
+        gene_data = retrieve_grouper_records(normalized_id)
+        gene_data.each do |source_name, source_data|
+          source = @sources[source_name.to_sym]
+
+          source_data['records'].each do |record|
+            claim = create_gene_claim(record, source)
+            add_grouper_claim_aliases(claim, record)
+            add_grouper_claim_attribute(claim, record)
+
+            add_claim_to_gene(claim, gene.concept_id)
+          end
+        end
+      end
+
+      def create_new_gene(concept_id)
+        gene_response = retrieve_normalizer_response(concept_id)
+        name = get_normalized_name(gene_response)
+        gene = Gene.where(
+          concept_id: concept_id,
+          name: name,
+          long_name: retrieve_extension(gene_response, 'approved_name')
+        ).first_or_create
+
+        add_grouper_data(gene, concept_id)
+      end
+
+      def normalizable_ids
+        [
+          GeneNomenclature::HGNC_ID,
+          GeneNomenclature::NCBI_ID,
+          GeneNomenclature::ENSEMBL_ID
+        ]
+      end
+
+
+      def group_gene_claim(gene_claim)
+        normalized_id = normalize_claim(gene_claim, gene_claim.gene_claim_aliases)
+        return if normalized_id.nil?
+
+        create_new_gene(normalized_id) if Gene.find_by(concept_id: normalized_id).nil?
+        add_claim_to_gene(gene_claim, normalized_id)
       end
     end
   end

--- a/server/lib/genome/names.rb
+++ b/server/lib/genome/names.rb
@@ -23,28 +23,31 @@ module Genome
       PRIMARY_NAME = 'Primary Name'
 
       DEVELOPMENT_NAME = 'Development Name'
-      ALIAS = 'ALIAS'
+      ALIAS = 'Alias'
       TRADE_NAME = 'Trade Name'
       GENERIC_NAME = 'Generic Name'
       XREF = 'Xref'
-
-      RXNORM_ID = 'RxNorm ID'
-      HEMONC_ID = 'HemOnc ID'
-      DRUGSATFDA_ID = 'Drugs@FDA ID'
-      CHEMIDPLUS_ID = 'ChemIDplus ID'
-      WIKIDATA_ID = 'Wikidata ID'
       CONCEPT_ID = 'Concept ID'
-      GTOP_LIGAND_NAME = 'GuideToPharmacology Ligand Name'
-      GTOP_LIGAND_ID = 'GuideToPharmacology Ligand ID'
+
+      # IDs generally recognized by thera-py
+      RXNORM_ID = 'RxNorm ID'
+      NCIT_ID = 'NCIt ID'
       DRUGBANK_ID = 'DrugBank ID'
-      PHARMGKB_ID = 'PharmGKB ID'
       CHEMBL_ID = 'ChEMBL ID'
       PUBCHEM_COMPOUND_ID = 'PubChem Compound ID'
+      HEMONC_ID = 'HemOnc ID'
+      CHEMIDPLUS_ID = 'ChemIDplus ID'
+      WIKIDATA_ID = 'Wikidata ID'
+      GTOP_LIGAND_ID = 'GuideToPharmacology Ligand ID'
       PUBCHEM_SUBSTANCE_ID = 'PubChem Substance ID'
-      NCIT_ID = 'NCIt ID'
+      DRUGSATFDA_ID = 'Drugs@FDA ID'
+
+      # other resource-specific stuff
+      GTOP_LIGAND_NAME = 'GuideToPharmacology Ligand Name'
+      PHARMGKB_ID = 'PharmGKB ID'
       PFAM_ID = 'PFAM ID'
       TTD_ID = 'TTD ID'
-      CIVIC_TID = "CIViC Therapy ID"
+      CIVIC_TID = 'CIViC Therapy ID'
     end
 
     module DrugAttributeName
@@ -66,13 +69,17 @@ module Genome
       SYNONYM = 'Gene Synonym'
       DESCRIPTION = 'Description'
       PREVIOUS_SYMBOL = 'Previous Symbol'
+      CONCEPT_ID = 'Concept ID'
 
-      NCBI_NAME = 'NCBI Gene Name'
+      # IDs generally recognzied by the gene normalizer
       NCBI_ID = 'NCBI Gene ID'
-      REFSEQ_ACC = 'RefSeq Accession'
-      ENSEMBL_ID = 'Ensembl Gene ID'
       HGNC_ID = 'HGNC ID'
+      ENSEMBL_ID = 'Ensembl Gene ID'
       UNIPROTKB_ID = 'UniProtKB ID'
+      REFSEQ_ACC = 'RefSeq Accession'
+
+      # other resource-specific stuff
+      NCBI_NAME = 'NCBI Gene Name'
       UNIPROTKB_NAME = 'UniProtKB Entry Name'
       UNIPROTKB_PROTEIN_NAME = 'UniProtKB Protein Name'
       UNIPROTKB_GENE_NAME = 'UniProtKB Gene Name'
@@ -82,7 +89,6 @@ module Genome
       CHEMBL_ID = 'ChEMBL ID'
       GTOP_ID = 'GuideToPharmacology ID'
       GENBANK_ID = 'GenBank Protein ID'
-      CONCEPT_ID = 'Concept ID'
     end
 
     module GeneAttributeName

--- a/server/lib/tasks/groupers.rake
+++ b/server/lib/tasks/groupers.rake
@@ -28,7 +28,7 @@ namespace :dgidb do
     task genes: :environment do
       time = Benchmark.measure do
         Utils::Logging.without_sql do
-          Genome::Groupers::GeneGrouper.new.run
+          Genome::Groupers::GeneGrouper.new.group_claims
         end
       end
       puts "Grouped genes in #{time.real.truncate(2)}s"
@@ -38,7 +38,7 @@ namespace :dgidb do
     task drugs: :environment do
       time = Benchmark.measure do
         Utils::Logging.without_sql do
-          Genome::Groupers::DrugGrouper.new.run
+          Genome::Groupers::DrugGrouper.new.group_claims
         end
       end
       puts "Grouped drugs in #{time.real.truncate(2)}s"


### PR DESCRIPTION
This looks like a lot of code changes but it's actually a fairly simple fix (that was made more complicated by aforementioned spaghettiness). Basically, when trying to group a drug or gene, we now do three steps

1. Collect claim name/aliases that have `nomenclature` values taken from a select set of identifier spaces (e.g., for genes, collect all name/aliases that are an HGNC ID, an NCBI ID, or an Ensembl ID). Sort them by an order of preference (for genes, HGNC > NCBI > Ensembl). Take the *first* match. This is the new part.
2. If that fails, and if the claim name wasn't one of the previously selected IDs, run it through the normalizer, and put it in that group if it matches.
3. Failing that, do the previous alias-based "voting" that we'd been falling back on previously. No change here, except this is done *only* on aliases/trade names/lesser known IDs.