### PR TITLE
Exclude unused CIViC Therapies

### DIFF
--- a/server/lib/genome/importers/api_importers/civic/api_client.rb
+++ b/server/lib/genome/importers/api_importers/civic/api_client.rb
@@ -52,7 +52,7 @@ module Genome; module Importers; module ApiImporters; module Civic
 
     DrugsQuery = CivicApi::Client.parse <<-GRAPHQL
       query ($after: String!) {
-        therapies(first: 50, after: $after) {
+        therapies(first: 50, hasLinkedEvidence: true, after: $after) {
           pageInfo {
             endCursor
             hasNextPage


### PR DESCRIPTION
This utilizes a new filter added in griffithlab/civic-v2#1212 to exclude Therapies from import unless they have at least one linked, non-rejected Evidence Item or Assertion.

We won't be able to deploy it until the referenced PR is merged and deployed in CIViC; I will follow up here when it is.

closes #576 

(Test failure is the result of the filter not existing on the prod CIViC schema yet)