### PR TITLE
fix: Lazy load CIViC GraphQL queries

### DIFF
--- a/server/lib/genome/importers/api_importers/civic/api_client.rb
+++ b/server/lib/genome/importers/api_importers/civic/api_client.rb
@@ -3,135 +3,144 @@ require "graphql/client/http"
 
 module Genome; module Importers; module ApiImporters; module Civic
   class ApiClient
+    attr_reader :genes_query, :drugs_query, :interactions_query, :client
+
+    def initialize
+      http = GraphQL::Client::HTTP.new('https://civicdb.org/api/graphql/') do
+        def headers(_context)
+          { 'User-Agent': 'DGIdb CIViC importer' }
+        end
+      end
+
+      schema = GraphQL::Client.load_schema(http)
+      @client = GraphQL::Client.new(schema: schema, execute: http)
+      @client.allow_dynamic_queries = true
+      @genes_query = client.parse(genes_query_contents)
+      @drugs_query = client.parse(drugs_query_contents)
+      @interactions_query = client.parse(interactions_query_contents)
+    end
 
     def enumerate_drugs
-      response = send_query(DrugsQuery)
+      response = send_query(drugs_query)
       Enumerator.new do |y|
         while response.therapies.page_info.has_next_page === true do
           response.therapies.edges.each { |edge| y << edge.node }
-          response = send_query(DrugsQuery, response.therapies.page_info.end_cursor)
+          response = send_query(drugs_query, response.therapies.page_info.end_cursor)
         end
         response.therapies.edges.each { |edge| y << edge.node }
       end
     end
     def enumerate_genes
-      response = send_query(GenesQuery)
+      response = send_query(genes_query)
       Enumerator.new do |y|
         while response.genes.page_info.has_next_page === true do
           response.genes.edges.each { |edge| y << edge.node }
-          response = send_query(GenesQuery, response.genes.page_info.end_cursor)
+          response = send_query(genes_query, response.genes.page_info.end_cursor)
         end
         response.genes.edges.each { |edge| y << edge.node }
       end
     end
 
     def enumerate_evidence_items
-      response = send_query(InteractionsQuery)
+      response = send_query(interactions_query)
       Enumerator.new do |y|
         while response.evidence_items.page_info.has_next_page === true do
           response.evidence_items.edges.each { |edge| y << edge.node }
-          response = send_query(InteractionsQuery, response.evidence_items.page_info.end_cursor)
+          response = send_query(interactions_query, response.evidence_items.page_info.end_cursor)
         end
         response.evidence_items.edges.each { |edge| y << edge.node }
       end
     end
 
     private
-
-    module CivicApi
-      api_endpoint = 'https://civicdb.org/api/graphql/'
-      HTTP = GraphQL::Client::HTTP.new(api_endpoint) do
-        def headers(_context)
-          { 'User-Agent': 'DGIdb CIViC importer' }
-        end
-      end
-
-      Schema = GraphQL::Client.load_schema(HTTP)
-      Client = GraphQL::Client.new(schema: Schema, execute: HTTP)
+    def drugs_query_contents
+      <<-GRAPHQL
+        query ($after: String!) {
+          therapies(first: 50, hasLinkedEvidence: true, after: $after) {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+            edges {
+              cursor
+              node {
+                id
+                name
+                ncitId
+              }
+            }
+          }
+        }
+      GRAPHQL
     end
 
-    DrugsQuery = CivicApi::Client.parse <<-GRAPHQL
-      query ($after: String!) {
-        therapies(first: 50, hasLinkedEvidence: true, after: $after) {
-          pageInfo {
-            endCursor
-            hasNextPage
-          }
-          edges {
-            cursor
-            node {
-              id
-              name
-              ncitId
+    def genes_query_contents
+      <<-GRAPHQL
+        query ($after: String!) {
+          genes(first: 50, after: $after) {
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+            edges {
+              cursor
+              node {
+                id
+                name
+                entrezId
+                fullName
+                featureAliases
+              }
             }
           }
         }
-      }
-    GRAPHQL
+      GRAPHQL
+    end
 
-    GenesQuery = CivicApi::Client.parse <<-GRAPHQL
-      query ($after: String!) {
-        genes(first: 50, after: $after) {
-          pageInfo {
-            endCursor
-            hasNextPage
-          }
-          edges {
-            cursor
-            node {
-              id
-              name
-              entrezId
-              fullName
-              featureAliases
+    def interactions_query_contents
+      <<-GRAPHQL
+        query ($after: String!) {
+          evidenceItems(first: 50, after: $after, evidenceType: PREDICTIVE) {
+            pageInfo {
+              endCursor
+              hasNextPage
             }
-          }
-        }
-      }
-    GRAPHQL
-
-    InteractionsQuery = CivicApi::Client.parse <<-GRAPHQL
-      query ($after: String!) {
-        evidenceItems(first: 50, after: $after, evidenceType: PREDICTIVE) {
-          pageInfo {
-            endCursor
-            hasNextPage
-          }
-          edges {
-            node {
-              id
-              evidenceDirection
-              evidenceRating
-              status
-              significance
-              evidenceLevel
-              molecularProfile {
-                variants {
-                  feature {
-                    featureInstance {
-                      __typename
-                      ... on Gene {
-                        name
+            edges {
+              node {
+                id
+                evidenceDirection
+                evidenceRating
+                status
+                significance
+                evidenceLevel
+                molecularProfile {
+                  variants {
+                    feature {
+                      featureInstance {
+                        __typename
+                        ... on Gene {
+                          name
+                        }
                       }
                     }
                   }
                 }
-              }
-              therapies {
-                name
-              }
-              source {
-                citationId
-                sourceType
+                therapies {
+                  name
+                }
+                source {
+                  citationId
+                  sourceType
+                }
               }
             }
           }
         }
-      }
-    GRAPHQL
+      GRAPHQL
+    end
 
     def send_query(query, cursor = '')
-      response = CivicApi::Client.query(query, variables: { 'after': cursor })
+      response = client.query(query, variables: { 'after': cursor })
       response.data
     end
   end


### PR DESCRIPTION
The ruby graphql client library generally recommends parsing queries against the schema at boot to avoid runtime errors and ensure you're not accepting arbitrary user injected strings (https://github.com/github-community-projects/graphql-client/blob/master/guides/dynamic-query-error.md). 

This unfortunately adds a boot-time dependency on connecting to the CIViC instance to retrieve the schema. The recommended workaround in the README is to include a static JSON dump of the schema in the app: https://github.com/github-community-projects/graphql-client?tab=readme-ov-file#configuration. This seems like it would be a pain point, having to keep this file up-to-date every time we make a change to the CIViC schema.

Given that these are not user-input queries but internally created for the purpose of the importer, I think its probably an okay compromise in this case to turn the "allow dynamic queries" flag on and lazily load these to eliminate the dependency on CIViC unless you're actively running the CIViC importer.

This PR removes the static queries, client, and schema objects and instead initializes them only when a new instance of the CIViC ApiClient class is created.