### PR TITLE
fix: use correct civic source type enum

### DIFF
--- a/server/lib/genome/importers/api_importers/civic/importer.rb
+++ b/server/lib/genome/importers/api_importers/civic/importer.rb
@@ -60,7 +60,7 @@ module Genome
             if ev_item.source.citation_id.present? && ev_item.source.source_type == 'PUBMED'
               create_interaction_claim_publication(ic, ev_item.source.citation_id)
             end
-            create_interaction_claim_link(ic, "ev_itemD#{ev_item.id}", "https://civicdb.org/evidence/#{ev_item.id}")
+            create_interaction_claim_link(ic, "EID#{ev_item.id}", "https://civicdb.org/evidence/#{ev_item.id}")
           end
 
           # current policy is to skip items with poor rating/level, anything that doesn't support the claim,


### PR DESCRIPTION
close #588 

We were previously checking that the source type was `"PubMed"` but it appears to be `"PUBMED"` now. I'm wondering if we could code this into the graphql query in a way that references the enum rather than hardcoding it on our side.

Also made some small style changes that are purely a distraction.