### PR TITLE
feat: add date to latest row on download page

### DIFF
--- a/client/src/pages/Downloads/Files/Files.tsx
+++ b/client/src/pages/Downloads/Files/Files.tsx
@@ -13,9 +13,10 @@ import Paper from '@mui/material/Paper';
 // style
 import './Files.scss';
 
-function getDataObj(date: string) {
+function getDataObj(date: string, label?: string) {
   return {
     date,
+    label: label ?? date,
     interactions: 'interactions.tsv',
     genes: 'genes.tsv',
     drugs: 'drugs.tsv',
@@ -24,7 +25,7 @@ function getDataObj(date: string) {
 }
 
 const rows = [
-  getDataObj('latest'),
+  getDataObj('latest', 'latest (2024-Dec)'),
   getDataObj('2024-Dec'),
   getDataObj('2024-Jun'),
   getDataObj('2023-Dec'),
@@ -63,7 +64,7 @@ export const Files = () => {
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
                 <TableCell component="th" scope="row">
-                  {row.date}
+                  {row.label}
                 </TableCell>
                 <TableCell align="center">
                   <a


### PR DESCRIPTION
This is to close #612 

This is a temporary solution. There's not a great solution currently to be able to actually get the date for the latest data, so we're going to hardcode it for now. We should create a followup ticket to be able to get the date from the file some other way. 