### PR TITLE
fix: clean up GtoP importer, resolve ID swap issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 client/package-lock.json
 client/yarn.lock
+client/.yarn/*
 server/data
 server/lib/data
 server/config/master.key

--- a/scripts/download_files.py
+++ b/scripts/download_files.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import boto3
 from botocore.exceptions import ClientError
 from wags_tails.base_source import DataSource, UnversionedDataSource, RemoteDataError
+from wags_tails.chembl import ChemblData
 from wags_tails.utils.storage import get_latest_local_file
 from wags_tails.utils.downloads import HTTPS_REQUEST_TIMEOUT, download_http, handle_zip
 from wags_tails.utils.versioning import DATE_VERSION_PATTERN, parse_file_version
@@ -519,15 +520,23 @@ for SourceClass in [
     CancerCommons,
     Caris,
     Cgi,
+    ChemblData,
+    CkbCoreDrugClaims,
+    CkbCoreGeneClaimAliases,
+    CkbCoreGeneClaims,
+    CkbCoreInteractionClaimAttributes,
+    CkbCoreInteractionClaimLinks,
+    CkbCoreInteractionClaimPublications,
+    CkbCoreInteractionClaims,
     ClearityFoundationBiomarkers,
     ClearityFoundationClinicalTrial,
     Cosmic,
     Dgene,
     DocmDrugClaims,
     DocmGeneClaims,
-    DocmInteractionClaims,
     DocmInteractionClaimAttributes,
     DocmInteractionClaimPublications,
+    DocmInteractionClaims,
     DrugbankProtected,
     Dtc,
     Fda,
@@ -542,11 +551,11 @@ for SourceClass in [
     MyCancerGenomeClinicalTrial,
     Nci,
     OncoKbDrugClaims,
-    OncoKbGeneClaims,
     OncoKbGeneClaimAliases,
-    OncoKbInteractionClaims,
-    OncoKbInteractionClaimLinks,
+    OncoKbGeneClaims,
     OncoKbInteractionClaimAttributes,
+    OncoKbInteractionClaimLinks,
+    OncoKbInteractionClaims,
     Oncomine,
     PharmGkbRelations,
     RussLampel,

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
+++ b/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
@@ -20,7 +20,7 @@ module Genome
               gene_file_path, 'targets_and_families'
             )
             @source_db_name = 'GuideToPharmacology'
-            @valid_gtop_ids = Set.new
+            @gene_claims_by_gtop_id = {}
           end
 
           def create_claims
@@ -130,42 +130,38 @@ module Genome
             'vgic' => 'ION CHANNEL'
           }
 
-          def import_target_row(row)
-            # skip if missing NCBI ID -- some targets are quite sparsely described
-            # and maybe don't refer to a human context
-            ncbi_lui = row['Human Entrez Gene']&.strip
-            return if ncbi_lui.blank? || ncbi_lui.include?('|')
-
-            # skip if missing target ID (this is probably impossible)
-            gtop_lui = row['Target id']&.strip
-            raise "Missing Target id for row: #{row.inspect}" if gtop_lui.blank?
-
-            @valid_gtop_ids.add(gtop_lui)
-            gene_claim = create_gene_claim("IUPHAR.RECEPTOR:#{gtop_lui}", GeneNomenclature::GTOP_ID)
-
-            create_alias_if_present(gene_claim, row['HGNC id'], GeneNomenclature::HGNC_ID, prefix: 'hgnc:')
-            create_alias_if_present(gene_claim, row['HGNC name'], GeneNomenclature::NAME)
-            create_alias_if_present(gene_claim, row['HGNC symbol'], GeneNomenclature::SYMBOL,
-                                    reject_numeric_only: true)
-            create_alias_if_present(gene_claim, row['Target name'], GeneNomenclature::NAME)
-
-            create_refseq_aliases(gene_claim, row['Human nucleotide RefSeq'])
-            create_refseq_aliases(gene_claim, row['Human protein RefSeq'])
-
-            create_prefixed_aliases(gene_claim, row['Human SwissProt'], GeneNomenclature::UNIPROTKB_ID,
-                                    prefix: 'uniprot:')
-
-            create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_NAME, row['Family name'])
-            create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_ID,
-                                        "iuphar.family:#{row['Family id']}")
-
-            create_gene_claim_category(gene_claim, CATEGORY_LOOKUP[row['Type']]) if CATEGORY_LOOKUP.key? row['Type']
-          end
-
           def import_gene_claims
             CSV.foreach(gene_file_path, headers: true,
                                         skip_lines: /GtoPdb Version/, col_sep: "\t") do |row|
-              import_target_row(row)
+              # skip if missing NCBI ID -- some targets are quite sparsely described
+              # and maybe don't refer to a human context
+              ncbi_lui = row['Human Entrez Gene']&.strip
+              next if ncbi_lui.blank? || ncbi_lui.include?('|')
+
+              # skip if missing target ID (this is probably impossible)
+              gtop_lui = row['Target id']&.strip
+              raise "Missing Target id for row: #{row.inspect}" if gtop_lui.blank?
+
+              gene_claim = create_gene_claim("IUPHAR.RECEPTOR:#{gtop_lui}", GeneNomenclature::GTOP_ID)
+              @gene_claims_by_gtop_id[gtop_lui] = gene_claim
+
+              create_alias_if_present(gene_claim, row['HGNC id'], GeneNomenclature::HGNC_ID, prefix: 'hgnc:')
+              create_alias_if_present(gene_claim, row['HGNC name'], GeneNomenclature::NAME)
+              create_alias_if_present(gene_claim, row['HGNC symbol'], GeneNomenclature::SYMBOL,
+                                      reject_numeric_only: true)
+              create_alias_if_present(gene_claim, row['Target name'], GeneNomenclature::NAME)
+
+              create_refseq_aliases(gene_claim, row['Human nucleotide RefSeq'])
+              create_refseq_aliases(gene_claim, row['Human protein RefSeq'])
+
+              create_prefixed_aliases(gene_claim, row['Human SwissProt'], GeneNomenclature::UNIPROTKB_ID,
+                                      prefix: 'uniprot:')
+
+              create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_NAME, row['Family name'])
+              create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_ID,
+                                          "iuphar.family:#{row['Family id']}")
+
+              create_gene_claim_category(gene_claim, CATEGORY_LOOKUP[row['Type']]) if CATEGORY_LOOKUP.key? row['Type']
             end
           end
 
@@ -174,10 +170,9 @@ module Genome
                                                skip_lines: /GtoPdb Version/, col_sep: "\t") do |line|
               next unless valid_interaction_line?(line)
 
-              gene_claim = create_gene_claim(
-                "NCBIGENE:#{line['Target ID']}", GeneNomenclature::NCBI_ID
-              )
-              create_gene_claim_aliases(gene_claim, line)
+              target_id = line['Target ID']&.strip
+              gene_claim = @gene_claims_by_gtop_id[target_id]
+              next unless gene_claim
 
               drug_claim = create_drug_claim("iuphar.ligand:#{line['Ligand ID']}".upcase,
                                              DrugNomenclature::GTOP_LIGAND_ID)
@@ -186,13 +181,9 @@ module Genome
                 create_drug_claim_attribute(drug_claim,
                                             DrugAttributeName::SPECIES_NAME, line['Ligand Species'])
               end
-              if line['Approved'] == 't'
-                create_drug_claim_approval_rating(drug_claim,
-                                                  'Approved')
-              end
+              create_drug_claim_approval_rating(drug_claim, 'Approved') if line['Approved'] == 't'
 
-              interaction_claim = create_interaction_claim(gene_claim,
-                                                           drug_claim)
+              interaction_claim = create_interaction_claim(gene_claim, drug_claim)
               type = line['Type'].downcase
               unless type == 'none'
                 create_interaction_claim_type(interaction_claim,
@@ -200,13 +191,10 @@ module Genome
               end
               unless blank?(line['Pubmed ID'])
                 line['Pubmed ID'].split('|').each do |pmid|
-                  create_interaction_claim_publication(
-                    interaction_claim, pmid
-                  )
+                  create_interaction_claim_publication(interaction_claim, pmid)
                 end
               end
-              create_interaction_claim_attributes(interaction_claim,
-                                                  line)
+              create_interaction_claim_attributes(interaction_claim, line)
               create_interaction_claim_link(interaction_claim, 'Ligand Biological Activity',
                                             "https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=#{line['Ligand ID']}&tab=biology")
             end
@@ -227,33 +215,9 @@ module Genome
             target_id = line['Target ID']&.strip
             return false if target_id.blank?
 
-            return false unless @valid_gtop_ids.include?(target_id)
+            return false unless @gene_claims_by_gtop_id.key?(target_id)
 
             true
-          end
-
-          def create_gene_claim_aliases(gene_claim, line)
-            unless blank?(line['Target'])
-              create_gene_claim_alias(gene_claim, line['Target'],
-                                      GeneNomenclature::NAME)
-            end
-            unless blank?(line['Target Ensembl Gene ID'])
-              line['Target Ensembl Gene ID'].split('|').each do |ensembl_id|
-                create_gene_claim_alias(gene_claim,
-                                        "ensembl:#{ensembl_id}", GeneNomenclature::NCBI_ID)
-              end
-            end
-            unless blank?(line['Target Gene Symbol'])
-              line['Target Gene Symbol'].split('|').each do |gene_symbol|
-                create_gene_claim_alias(gene_claim, gene_symbol, GeneNomenclature::SYMBOL)
-              end
-            end
-            return if blank?(line['Target UniProt ID'])
-
-            line['Target UniProt ID'].split('|').each do |uniprot_id|
-              create_gene_claim_alias(gene_claim,
-                                      "uniprot:#{uniprot_id}", GeneNomenclature::UNIPROTKB_ID)
-            end
           end
 
           def strip_tags(drug_alias)

--- a/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
+++ b/server/lib/genome/importers/file_importers/guide_to_pharmacology.rb
@@ -1,221 +1,308 @@
 include ActionView::Helpers::SanitizeHelper
 
-module Genome; module Importers; module FileImporters; module GuideToPharmacology;
-  # gene_file_path should point to `gtop_targets_and_families_*.tsv`
-  # interaction_file_path should point to `gtop_interactions_*.tsv`
-  class Importer < Genome::Importers::Base
-    attr_reader :interaction_file_path, :gene_file_path, :target_to_entrez
+require 'set'
 
-    def initialize(interaction_file_path, gene_file_path)
-      @interaction_file_path = handle_gtop_file_location(interaction_file_path, "interactions")
-      @gene_file_path = handle_gtop_file_location(gene_file_path, "targets_and_families")
-      @target_to_entrez = {}
-      @source_db_name = 'GuideToPharmacology'
-    end
+module Genome
+  module Importers
+    module FileImporters
+      module GuideToPharmacology
+        # gene_file_path should point to `gtop_targets_and_families_*.tsv`
+        # interaction_file_path should point to `gtop_interactions_*.tsv`
+        class Importer < Genome::Importers::Base
+          attr_reader :interaction_file_path, :gene_file_path,
+                      :target_to_entrez
 
-    def create_claims
-      import_gene_claims
-      import_interaction_claims
-    end
+          def initialize(interaction_file_path, gene_file_path)
+            @interaction_file_path = handle_gtop_file_location(
+              interaction_file_path, 'interactions'
+            )
+            @gene_file_path = handle_gtop_file_location(
+              gene_file_path, 'targets_and_families'
+            )
+            @source_db_name = 'GuideToPharmacology'
+            @valid_gtop_ids = Set.new
+          end
 
-    private
+          def create_claims
+            import_gene_claims
+            import_interaction_claims
+          end
 
-    def handle_gtop_file_location(file_path, datatype)
-      return file_path unless file_path.nil?
+          private
 
-      raise "Unrecognized GtoP datatype: #{datatype}" unless %w[targets_and_families interactions].include? datatype
+          def handle_gtop_file_location(file_path, datatype)
+            return file_path unless file_path.nil?
 
-      directory = "#{default_data_dir}/guidetopharmacology/"
-      Dir.glob(File.join(directory, "gtop_#{datatype}_*.tsv"))
-         .max_by { |file| file.match(/gtop_#{datatype}_(\d+)\.db/)[1].to_i rescue 0 }
-    end
+            raise "Unrecognized GtoP datatype: #{datatype}" unless %w[
+              targets_and_families interactions
+            ].include? datatype
 
-    def get_version
-      version = ''
-      File.open(@interaction_file_path, 'r') do |file|
-        header = file.readline.strip
-        match = header.match(/^"# GtoPdb Version: (\d+\.\d+)/)
-        version = match[1] if match
-      end
-      if version.empty?
-        Rails.logger.error("Could not extract version number from GtoP interactions file")
-      end
-      version
-    end
+            directory = "#{default_data_dir}/guidetopharmacology/"
+            Dir.glob(File.join(directory, "gtop_#{datatype}_*.tsv"))
+               .max_by do |file|
+              file.match(/gtop_#{datatype}_(\d+)\.db/)[1].to_i
+            rescue StandardError
+              0
+            end
+          end
 
-    def create_new_source
-      @source ||= Source.create(
-        base_url: 'http://www.guidetopharmacology.org/DATA/',
-        citation: 'Armstrong JF, Faccenda E, Harding SD, Pawson AJ, Southan C, Sharman JL, Campo B, Cavanagh DR, Alexander SPH, Davenport AP, Spedding M, Davies JA; NC-IUPHAR. The IUPHAR/BPS Guide to PHARMACOLOGY in 2020: extending immunopharmacology content and introducing the IUPHAR/MMV Guide to MALARIA PHARMACOLOGY. Nucleic Acids Res. 2020 Jan 8;48(D1):D1006-D1021. doi: 10.1093/nar/gkz951. PMID: 31691834; PMCID: PMC7145572.',
-        citation_short: 'Armstrong JF, et al. The IUPHAR/BPS Guide to PHARMACOLOGY in 2020: extending immunopharmacology content and introducing the IUPHAR/MMV Guide to MALARIA PHARMACOLOGY. Nucleic Acids Res. 2020 Jan 8;48(D1):D1006-D1021.',
-        pmid: '31691834',
-        pmcid: 'PMC7145572',
-        doi: '10.1093/nar/gkz951',
-        site_url: 'http://www.guidetopharmacology.org/',
-        source_db_name: source_db_name,
-        source_db_version: get_version,
-        source_trust_level_id: SourceTrustLevel.EXPERT_CURATED,
-        full_name: 'Guide to Pharmacology',
-        license: License::CC_BY_SA_4_0,
-        license_link: 'https://www.guidetopharmacology.org/about.jsp'
-      )
-      @source.source_types << SourceType.find_by(type: 'interaction')
-      @source.source_types << SourceType.find_by(type: 'potentially_druggable')
-      @source.save
-    end
+          def gtop_version
+            version = ''
+            File.open(@interaction_file_path, 'r') do |file|
+              header = file.readline.strip
+              match = header.match(/^"# GtoPdb Version: (\d+\.\d+)/)
+              version = match[1] if match
+            end
+            Rails.logger.error('Could not extract version number from GtoP interactions file') if version.empty?
+            version
+          end
 
-    def import_gene_claims
-      refseq_id_pattern = /^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ\_[A-Z]{4}\d+))(\.\d+)?$/
+          def create_new_source
+            @source ||= Source.create(
+              base_url: 'http://www.guidetopharmacology.org/DATA/',
+              citation: 'Armstrong JF, Faccenda E, Harding SD, Pawson AJ, Southan C, Sharman JL, Campo B, Cavanagh DR, Alexander SPH, Davenport AP, Spedding M, Davies JA; NC-IUPHAR. The IUPHAR/BPS Guide to PHARMACOLOGY in 2020: extending immunopharmacology content and introducing the IUPHAR/MMV Guide to MALARIA PHARMACOLOGY. Nucleic Acids Res. 2020 Jan 8;48(D1):D1006-D1021. doi: 10.1093/nar/gkz951. PMID: 31691834; PMCID: PMC7145572.',
+              citation_short: 'Armstrong JF, et al. The IUPHAR/BPS Guide to PHARMACOLOGY in 2020: extending immunopharmacology content and introducing the IUPHAR/MMV Guide to MALARIA PHARMACOLOGY. Nucleic Acids Res. 2020 Jan 8;48(D1):D1006-D1021.',
+              pmid: '31691834',
+              pmcid: 'PMC7145572',
+              doi: '10.1093/nar/gkz951',
+              site_url: 'http://www.guidetopharmacology.org/',
+              source_db_name: source_db_name,
+              source_db_version: gtop_version,
+              source_trust_level_id: SourceTrustLevel.EXPERT_CURATED,
+              full_name: 'Guide to Pharmacology',
+              license: License::CC_BY_SA_4_0,
+              license_link: 'https://www.guidetopharmacology.org/about.jsp'
+            )
+            @source.source_types << SourceType.find_by(type: 'interaction')
+            @source.source_types << SourceType.find_by(type: 'potentially_druggable')
+            @source.save
+          end
 
-      CSV.foreach(gene_file_path, headers: true, skip_lines: /GtoPdb Version/, col_sep: "\t") do |line|
-        gene_lui = line['Human Entrez Gene']
-        next if blank?(gene_lui) || gene_lui.include?('|')
+          def create_alias_if_present(gene_claim, value, nomenclature, prefix: nil,
+                                      reject_numeric_only: false)
+            value = value&.strip
+            return if value.blank?
+            return if reject_numeric_only && value.match?(/\A\d+\z/)
 
-        gene_claim = create_gene_claim("NCBIGENE:#{gene_lui}", GeneNomenclature::NCBI_ID)
-        target_to_entrez[line['Target id']] = gene_lui
-        unless blank?(line['HGNC id'])
-          create_gene_claim_alias(gene_claim, "hgnc:#{line['HGNC id']}", GeneNomenclature::HGNC_ID)
-        end
-        if blank?(line['HGNC symbol']) || (line['HGNC symbol'] != line['HGNC symbol'].to_i.to_s)
-          create_gene_claim_alias(gene_claim, line['HGNC symbol'], GeneNomenclature::SYMBOL)
-        end
-        create_gene_claim_alias(gene_claim, line['HGNC name'], GeneNomenclature::NAME) unless blank?(line['HGNC name'])
-        create_gene_claim_alias(gene_claim, "iuphar.receptor:#{line['Target id']}", GeneNomenclature::GTOP_ID)
-        create_gene_claim_alias(gene_claim, line['Target name'], GeneNomenclature::NAME)
-        unless blank?(line['Human nucleotide RefSeq'])
-          line['Human nucleotide RefSeq'][7..].split('|') do |acc|
-            if acc.match(refseq_id_pattern)
+            value = "#{prefix}#{value}" if prefix
+            create_gene_claim_alias(gene_claim, value, nomenclature)
+          end
+
+          def create_prefixed_aliases(gene_claim, value, nomenclature, prefix:, separator: '|')
+            value = value&.strip
+            return if value.blank?
+
+            value.split(separator).each do |part|
+              part = part.strip
+              next if part.blank?
+
+              create_gene_claim_alias(gene_claim, "#{prefix}#{part}", nomenclature)
+            end
+          end
+
+          REFSEQ_ID_PATTERN = /^((AC|AP|NC|NG|NM|NP|NR|NT|NW|XM|XP|XR|YP|ZP)_\d+|(NZ_[A-Z]{4}\d+))(\.\d+)?$/
+
+          def create_refseq_aliases(gene_claim, value)
+            value = value&.strip
+            return if value.blank?
+
+            value = value[7..] if value.start_with?('RefSeq:')
+            return if value.blank?
+
+            value.split('|').each do |acc|
+              acc = acc.strip
+              next if acc.blank?
+              next unless acc.match?(REFSEQ_ID_PATTERN)
+
               create_gene_claim_alias(gene_claim, "refseq:#{acc}", GeneNomenclature::REFSEQ_ACC)
             end
           end
-        end
-        unless blank?(line['Human protein RefSeq'])
-          line['Human protein RefSeq'][7..].split('|') do |acc|
-            if acc.match(refseq_id_pattern)
-              create_gene_claim_alias(gene_claim, "refseq:#{acc}", GeneNomenclature::REFSEQ_ACC)
+
+          CATEGORY_LOOKUP = {
+            # "catalytic_receptor" => '',
+            'enzyme' => 'ENZYME',
+            'gpcr' => 'G PROTEIN COUPLED RECEPTOR',
+            'lgic' => 'ION CHANNEL',
+            'nhr' => 'NUCLEAR HORMONE RECEPTOR',
+            'other_ic' => 'ION CHANNEL',
+            # 'other_protein' => '',
+            'transporter' => 'TRANSPORTER',
+            'vgic' => 'ION CHANNEL'
+          }
+
+          def import_target_row(row)
+            # skip if missing NCBI ID -- some targets are quite sparsely described
+            # and maybe don't refer to a human context
+            ncbi_lui = row['Human Entrez Gene']&.strip
+            return if ncbi_lui.blank? || ncbi_lui.include?('|')
+
+            # skip if missing target ID (this is probably impossible)
+            gtop_lui = row['Target id']&.strip
+            raise "Missing Target id for row: #{row.inspect}" if gtop_lui.blank?
+
+            @valid_gtop_ids.add(gtop_lui)
+            gene_claim = create_gene_claim("IUPHAR.RECEPTOR:#{gtop_lui}", GeneNomenclature::GTOP_ID)
+
+            create_alias_if_present(gene_claim, row['HGNC id'], GeneNomenclature::HGNC_ID, prefix: 'hgnc:')
+            create_alias_if_present(gene_claim, row['HGNC name'], GeneNomenclature::NAME)
+            create_alias_if_present(gene_claim, row['HGNC symbol'], GeneNomenclature::SYMBOL,
+                                    reject_numeric_only: true)
+            create_alias_if_present(gene_claim, row['Target name'], GeneNomenclature::NAME)
+
+            create_refseq_aliases(gene_claim, row['Human nucleotide RefSeq'])
+            create_refseq_aliases(gene_claim, row['Human protein RefSeq'])
+
+            create_prefixed_aliases(gene_claim, row['Human SwissProt'], GeneNomenclature::UNIPROTKB_ID,
+                                    prefix: 'uniprot:')
+
+            create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_NAME, row['Family name'])
+            create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_ID,
+                                        "iuphar.family:#{row['Family id']}")
+
+            create_gene_claim_category(gene_claim, CATEGORY_LOOKUP[row['Type']]) if CATEGORY_LOOKUP.key? row['Type']
+          end
+
+          def import_gene_claims
+            CSV.foreach(gene_file_path, headers: true,
+                                        skip_lines: /GtoPdb Version/, col_sep: "\t") do |row|
+              import_target_row(row)
+            end
+          end
+
+          def import_interaction_claims
+            CSV.foreach(interaction_file_path, headers: true,
+                                               skip_lines: /GtoPdb Version/, col_sep: "\t") do |line|
+              next unless valid_interaction_line?(line)
+
+              gene_claim = create_gene_claim(
+                "NCBIGENE:#{line['Target ID']}", GeneNomenclature::NCBI_ID
+              )
+              create_gene_claim_aliases(gene_claim, line)
+
+              drug_claim = create_drug_claim("iuphar.ligand:#{line['Ligand ID']}".upcase,
+                                             DrugNomenclature::GTOP_LIGAND_ID)
+              create_drug_claim_aliases(drug_claim, line)
+              unless blank?(line['Ligand Species'])
+                create_drug_claim_attribute(drug_claim,
+                                            DrugAttributeName::SPECIES_NAME, line['Ligand Species'])
+              end
+              if line['Approved'] == 't'
+                create_drug_claim_approval_rating(drug_claim,
+                                                  'Approved')
+              end
+
+              interaction_claim = create_interaction_claim(gene_claim,
+                                                           drug_claim)
+              type = line['Type'].downcase
+              unless type == 'none'
+                create_interaction_claim_type(interaction_claim,
+                                              type)
+              end
+              unless blank?(line['Pubmed ID'])
+                line['Pubmed ID'].split('|').each do |pmid|
+                  create_interaction_claim_publication(
+                    interaction_claim, pmid
+                  )
+                end
+              end
+              create_interaction_claim_attributes(interaction_claim,
+                                                  line)
+              create_interaction_claim_link(interaction_claim, 'Ligand Biological Activity',
+                                            "https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=#{line['Ligand ID']}&tab=biology")
+            end
+            backfill_publication_information
+          end
+
+          # Valid interactions should:
+          # * describe humans
+          # * have pubchem substance IDs to ensure drug descriptiveness
+          # * have ensembl gene IDs to ensure gene descriptiveness
+          # * include a gene claim that we were able to ingest
+          def valid_interaction_line?(line)
+            return false unless line['Target Species'] == 'Human'
+            return false unless line['Target Ligand'].blank?
+            return false if line['Ligand PubChem SID'].blank?
+            return false if line['Target Ensembl Gene ID'].blank?
+
+            target_id = line['Target ID']&.strip
+            return false if target_id.blank?
+
+            return false unless @valid_gtop_ids.include?(target_id)
+
+            true
+          end
+
+          def create_gene_claim_aliases(gene_claim, line)
+            unless blank?(line['Target'])
+              create_gene_claim_alias(gene_claim, line['Target'],
+                                      GeneNomenclature::NAME)
+            end
+            unless blank?(line['Target Ensembl Gene ID'])
+              line['Target Ensembl Gene ID'].split('|').each do |ensembl_id|
+                create_gene_claim_alias(gene_claim,
+                                        "ensembl:#{ensembl_id}", GeneNomenclature::NCBI_ID)
+              end
+            end
+            unless blank?(line['Target Gene Symbol'])
+              line['Target Gene Symbol'].split('|').each do |gene_symbol|
+                create_gene_claim_alias(gene_claim, gene_symbol, GeneNomenclature::SYMBOL)
+              end
+            end
+            return if blank?(line['Target UniProt ID'])
+
+            line['Target UniProt ID'].split('|').each do |uniprot_id|
+              create_gene_claim_alias(gene_claim,
+                                      "uniprot:#{uniprot_id}", GeneNomenclature::UNIPROTKB_ID)
+            end
+          end
+
+          def strip_tags(drug_alias)
+            drug_alias.split('[PMID:')[0].strip
+          end
+
+          def create_drug_claim_aliases(drug_claim, line)
+            create_drug_claim_alias(drug_claim,
+                                    strip_tags(line['Ligand']).upcase, DrugNomenclature::GTOP_LIGAND_NAME)
+            create_drug_claim_alias(drug_claim,
+                                    "pubchem.substance:#{line['Ligand PubChem SID']}", DrugNomenclature::PUBCHEM_SUBSTANCE_ID)
+
+            return if blank?(line['Ligand Gene Symbol'])
+
+            line['Ligand Gene Symbol'].split('|').each do |gene_symbol|
+              create_drug_claim_attribute(drug_claim,
+                                          DrugAttributeName::GENE_SYMBOL, gene_symbol)
+            end
+          end
+
+          def blank?(value)
+            value.blank? || value == "''" || value == '""'
+          end
+
+          def create_interaction_claim_attributes(interaction_claim,
+                                                  line)
+            attributes = {
+              InteractionAttributeName::CONTEXT => line['Ligand Context'],
+              InteractionAttributeName::BINDING_SITE => line['Receptor Site'],
+              InteractionAttributeName::ASSAY => line['Assay Description'],
+              InteractionAttributeName::MOA => line['Action'],
+              InteractionAttributeName::DETAILS => line['Action comment'],
+              InteractionAttributeName::ENDOGENOUS_DRUG => line['Endogenous'],
+              InteractionAttributeName::DIRECT => line['Primary Target']
+            }
+            boolean_parser = {
+              't' => 'True',
+              'f' => 'False'
+            }
+            attributes.each do |name, value|
+              next if blank?(value)
+
+              parsed_value = boolean_parser[value] || value
+              create_interaction_claim_attribute(interaction_claim,
+                                                 name, parsed_value)
             end
           end
         end
-        unless blank?(line['Human SwissProt'])
-          line['Human SwissProt'].split('|').each do |swissprot_id|
-            create_gene_claim_alias(gene_claim, "uniprot:#{swissprot_id}", GeneNomenclature::UNIPROTKB_ID)
-          end
-        end
-
-        create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_NAME, line['Family name'])
-        create_gene_claim_attribute(gene_claim, GeneAttributeName::GTOP_FAMILY_ID, "iuphar.family:#{line['Family id']}")
-
-        category_lookup = {
-          # "catalytic_receptor" => '',
-          'enzyme' => 'ENZYME',
-          'gpcr' => 'G PROTEIN COUPLED RECEPTOR',
-          'lgic' => 'ION CHANNEL',
-          'nhr' => 'NUCLEAR HORMONE RECEPTOR',
-          'other_ic' => 'ION CHANNEL',
-          # 'other_protein' => '',
-          'transporter' => 'TRANSPORTER',
-          'vgic' => 'ION CHANNEL'
-        }
-        create_gene_claim_category(gene_claim, category_lookup[line['Type']]) if category_lookup.key? line['Type']
-      end
-    end
-
-    def import_interaction_claims
-      CSV.foreach(interaction_file_path, headers: true, skip_lines: /GtoPdb Version/, col_sep: "\t") do |line|
-        next unless valid_interaction_line?(line)
-
-        gene_claim = create_gene_claim("NCBIGENE:#{line['Target ID']}", GeneNomenclature::NCBI_ID)
-        create_gene_claim_aliases(gene_claim, line)
-
-        drug_claim = create_drug_claim("iuphar.ligand:#{line['Ligand ID']}".upcase,
-                                       DrugNomenclature::GTOP_LIGAND_ID)
-        create_drug_claim_aliases(drug_claim, line)
-        unless blank?(line['Ligand Species'])
-          create_drug_claim_attribute(drug_claim, DrugAttributeName::SPECIES_NAME, line['Ligand Species'])
-        end
-        create_drug_claim_approval_rating(drug_claim, 'Approved') if line['Approved'] == 't'
-
-        interaction_claim = create_interaction_claim(gene_claim, drug_claim)
-        type = line['Type'].downcase
-        create_interaction_claim_type(interaction_claim, type) unless type == 'none'
-        unless blank?(line['Pubmed ID'])
-          line['Pubmed ID'].split('|').each do |pmid|
-            create_interaction_claim_publication(interaction_claim, pmid)
-          end
-        end
-        create_interaction_claim_attributes(interaction_claim, line)
-        create_interaction_claim_link(interaction_claim, 'Ligand Biological Activity', "https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=#{line['Ligand ID']}&tab=biology")
-      end
-      backfill_publication_information
-    end
-
-    # Valid interactions should:
-    # * describe humans
-    # * have pubchem substance IDs to ensure drug descriptiveness
-    # * have ensembl gene IDs to ensure gene descriptiveness
-    # * have NCBI gene IDs to ensure gene descriptiveness
-    def valid_interaction_line?(line)
-      line['Target Species'] == 'Human' && blank?(line['Target Ligand']) && !blank?(line['Ligand PubChem SID']) && !blank?(line['Target Ensembl Gene ID']) && !blank?(target_to_entrez[line['Target ID']])
-    end
-
-    def create_gene_claim_aliases (gene_claim, line)
-      create_gene_claim_alias(gene_claim, line['Target'], GeneNomenclature::NAME) unless blank?(line['Target'])
-      unless blank?(line['Target Ensembl Gene ID'])
-        line['Target Ensembl Gene ID'].split('|').each do |ensembl_id|
-          create_gene_claim_alias(gene_claim, "ensembl:#{ensembl_id}", GeneNomenclature::NCBI_ID)
-        end
-      end
-      unless blank?(line['Target Gene Symbol'])
-        line['Target Gene Symbol'].split('|').each do |gene_symbol|
-          create_gene_claim_alias(gene_claim, gene_symbol, GeneNomenclature::SYMBOL)
-        end
-      end
-      unless blank?(line['Target UniProt ID'])
-        line['Target UniProt ID'].split('|').each do |uniprot_id|
-          create_gene_claim_alias(gene_claim, "uniprot:#{uniprot_id}", GeneNomenclature::UNIPROTKB_ID)
-        end
-      end
-    end
-
-    def strip_tags(drug_alias)
-      drug_alias.split('[PMID:')[0].strip
-    end
-
-    def create_drug_claim_aliases(drug_claim, line)
-      create_drug_claim_alias(drug_claim, strip_tags(line['Ligand']).upcase, DrugNomenclature::GTOP_LIGAND_NAME)
-      create_drug_claim_alias(drug_claim, "pubchem.substance:#{line['Ligand PubChem SID']}", DrugNomenclature::PUBCHEM_SUBSTANCE_ID)
-
-      return if blank?(line['Ligand Gene Symbol'])
-
-      line['Ligand Gene Symbol'].split('|').each do |gene_symbol|
-        create_drug_claim_attribute(drug_claim, DrugAttributeName::GENE_SYMBOL, gene_symbol)
-      end
-    end
-
-    def blank?(value)
-      value.blank? || value == "''" || value == '""'
-    end
-
-    def create_interaction_claim_attributes(interaction_claim, line)
-      attributes = {
-        InteractionAttributeName::CONTEXT => line['Ligand Context'],
-        InteractionAttributeName::BINDING_SITE => line['Receptor Site'],
-        InteractionAttributeName::ASSAY => line['Assay Description'],
-        InteractionAttributeName::MOA => line['Action'],
-        InteractionAttributeName::DETAILS => line['Action comment'],
-        InteractionAttributeName::ENDOGENOUS_DRUG => line['Endogenous'],
-        InteractionAttributeName::DIRECT => line['Primary Target']
-      }
-      boolean_parser = {
-        't' => 'True',
-        'f' => 'False'
-      }
-      attributes.each do |name, value|
-        next if blank?(value)
-
-        parsed_value = boolean_parser[value] || value
-        create_interaction_claim_attribute(interaction_claim, name, parsed_value)
       end
     end
   end
-end; end; end; end;
+end


### PR DESCRIPTION
Fixes the GtoP data issue, makes the GtoP target ID the primary for the gene claim, generally cleans up the importer code