### PR TITLE
Add Docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.venv
+**/.DS_Store
+
+client/build
+client/node_modules
+client/.yarn/install-state.gz
+
+server/.bundle
+server/log/*
+server/public/*
+server/storage/*
+server/tmp/*
+server/vendor
+server/config/master.key

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Generate with `openssl rand -hex 64`.
+SECRET_KEY_BASE=replace-with-a-secret-key-base
+
+DGIDB_HTTP_PORT=8080
+
+# Optional image overrides; the defaults are public images on GHCR.
+# DGIDB_APPLICATION_IMAGE=ghcr.io/dgidb/dgidb-v5:latest
+# DGIDB_DATABASE_IMAGE=ghcr.io/dgidb/dgidb-v5-database:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+.env
 client/package-lock.json
-client/yarn.lock
 client/.yarn/*
 server/data
 server/lib/data
@@ -8,8 +8,8 @@ server/config/master.key
 docs/build
 *.DS_Store
 *.lock
+!client/yarn.lock
 *.log
-client/yarn.lock
 
 .ruby-version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM node:24-bookworm-slim AS frontend-build
+
+WORKDIR /build/client
+
+RUN corepack enable && corepack prepare yarn@4.5.1 --activate
+
+COPY client/package.json client/yarn.lock client/.yarnrc.yml ./
+RUN yarn install --immutable
+
+COPY client/ ./
+
+ARG REACT_APP_API_URI=/api/graphql
+ARG REACT_APP_DOMAIN=
+
+# react-scripts 5 requires the legacy provider with Node's newer OpenSSL.
+ENV CI=false \
+    GENERATE_SOURCEMAP=false \
+    NODE_OPTIONS=--openssl-legacy-provider \
+    REACT_APP_API_URI=${REACT_APP_API_URI} \
+    REACT_APP_DOMAIN=${REACT_APP_DOMAIN} \
+    REACT_APP_ANALYTICS=false
+
+RUN yarn react-scripts build
+
+FROM ruby:4.0.3-slim-bookworm AS app-base
+
+WORKDIR /rails
+
+ENV RAILS_ENV=production \
+    BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_WITHOUT=development:test \
+    PATH=/usr/local/bundle/bin:$PATH
+
+FROM app-base AS app-build
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      libyaml-dev \
+      pkg-config \
+      zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY server/Gemfile server/Gemfile.lock ./
+RUN bundle install && \
+    rm -rf /root/.bundle "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile -j 1 --gemfile
+
+COPY server/ ./
+RUN bundle exec bootsnap precompile -j 1 app/ lib/
+
+RUN rm -rf public
+COPY --from=frontend-build /build/client/build/ public/
+
+FROM app-base AS app
+
+LABEL org.opencontainers.image.source="https://github.com/dgidb/dgidb-v5" \
+      org.opencontainers.image.description="DGIdb Rails API and React application"
+
+RUN gem install thruster --version 0.1.23 --no-document && \
+    groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
+
+COPY --chown=rails:rails --from=app-build /usr/local/bundle /usr/local/bundle
+COPY --chown=rails:rails --from=app-build /rails /rails
+
+USER 1000:1000
+
+ENV RAILS_LOG_TO_STDOUT=1 \
+    RAILS_SERVE_STATIC_FILES=1 \
+    DGIDB_CONTAINER=1 \
+    RAILS_MAX_THREADS=5 \
+    TARGET_PORT=3000 \
+    HTTP_PORT=80
+
+EXPOSE 80
+
+CMD ["thrust", "bundle", "exec", "puma", "--config", "config/puma.rb"]

--- a/README.md
+++ b/README.md
@@ -145,3 +145,38 @@ In practice, Prettier will do most of the formatting work for you to be in accor
 ```shell
 yarn run prettier --write path/to/file
 ```
+
+## Run with Docker
+
+The published images support Linux on AMD64 and ARM64. Docker selects the correct image automatically, including on Apple silicon. The application image contains Rails, the production React bundle, and Thruster. The database image contains PostgreSQL 18 with the DGIdb dataset already loaded. Docker Compose is the only runtime dependency.
+
+Download [compose.yaml](./compose.yaml) and [.env.example](./.env.example) from the same DGIdb release into an empty directory. Create the environment file and replace its placeholder with a random secret; `openssl rand -hex 64` is one way to generate it.
+
+```shell
+cp .env.example .env
+```
+
+Pull and start the public images; no source checkout or image build is needed:
+
+```shell
+docker compose pull
+docker compose up --detach
+docker compose logs --follow db app
+```
+
+Open `http://localhost:8080`. The database is read-only, starts from the dataset built into its image, and is not exposed to the host.
+
+To update the application or dataset, repeat `docker compose pull` and `docker compose up --detach`. There is no database volume or startup import: changing the database image changes the dataset. Set `DGIDB_APPLICATION_IMAGE` and `DGIDB_DATABASE_IMAGE` in `.env` when you want to pin published tags or digests instead of `latest`.
+
+Thruster listens over HTTP in the supplied Compose configuration. Terminate TLS at the deployment platform or load balancer.
+
+### Publishing container images
+
+Maintainers build and push both Linux architectures with the standalone build configuration:
+
+```shell
+docker login ghcr.io
+DGIDB_DATA_RELEASE=2026-06b docker compose -f compose.build.yaml build --push
+```
+
+The database is initialized and loaded entirely during this build. Use a concrete `DGIDB_DATA_RELEASE` tag so the result is reproducible. Set `DGIDB_APPLICATION_IMAGE` or `DGIDB_DATABASE_IMAGE` to publish a non-`latest` image tag. Docker Desktop supplies cross-architecture emulation on Apple silicon. After first publishing each package, set its GHCR visibility to public so users can pull it without signing in.

--- a/compose.build.yaml
+++ b/compose.build.yaml
@@ -1,0 +1,21 @@
+services:
+  app:
+    image: ${DGIDB_APPLICATION_IMAGE:-ghcr.io/dgidb/dgidb-v5:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: app
+      platforms:
+        - linux/amd64
+        - linux/arm64
+
+  db:
+    image: ${DGIDB_DATABASE_IMAGE:-ghcr.io/dgidb/dgidb-v5-database:latest}
+    build:
+      context: .
+      dockerfile: docker/postgres.Dockerfile
+      args:
+        DGIDB_DATA_RELEASE: ${DGIDB_DATA_RELEASE:-latest}
+      platforms:
+        - linux/amd64
+        - linux/arm64

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,32 @@
+name: dgidb
+
+services:
+  db:
+    image: ${DGIDB_DATABASE_IMAGE:-ghcr.io/dgidb/dgidb-v5-database:latest}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "dgidb", "-d", "dgidb"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    restart: unless-stopped
+
+  app:
+    image: ${DGIDB_APPLICATION_IMAGE:-ghcr.io/dgidb/dgidb-v5:latest}
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}
+      RDS_HOSTNAME: db
+      RDS_PORT: 5432
+      RDS_USERNAME: dgidb
+    ports:
+      - "${DGIDB_HTTP_PORT:-8080}:80"
+    healthcheck:
+      test: ["CMD", "ruby", "-rnet/http", "-e", "exit(Net::HTTP.get_response(URI('http://127.0.0.1/up')).is_a?(Net::HTTPSuccess) ? 0 : 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+    restart: unless-stopped

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS data-download
+
+ARG DGIDB_DATA_RELEASE=latest
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y ca-certificates curl jq && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eu; \
+    if [ "$DGIDB_DATA_RELEASE" = "latest" ]; then \
+      release_endpoint="https://api.github.com/repos/dgidb/dgidb-data/releases/latest"; \
+    else \
+      release_endpoint="https://api.github.com/repos/dgidb/dgidb-data/releases/tags/$DGIDB_DATA_RELEASE"; \
+    fi; \
+    mkdir -p /opt/dgidb; \
+    curl --fail --location --silent --show-error \
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      "$release_endpoint" \
+      --output /opt/dgidb/release.json; \
+    asset_count="$(jq '[.assets[] | select(.name | test("\\.sql\\.gz$"))] | length' /opt/dgidb/release.json)"; \
+    [ "$asset_count" -eq 1 ]; \
+    asset_url="$(jq --raw-output '.assets[] | select(.name | test("\\.sql\\.gz$")) | .browser_download_url' /opt/dgidb/release.json)"; \
+    asset_digest="$(jq --raw-output '.assets[] | select(.name | test("\\.sql\\.gz$")) | .digest' /opt/dgidb/release.json)"; \
+    case "$asset_digest" in sha256:*) ;; *) echo "Release asset has no SHA-256 digest" >&2; exit 1 ;; esac; \
+    curl --fail --location --silent --show-error "$asset_url" --output /opt/dgidb/data.sql.gz; \
+    echo "${asset_digest#sha256:}  /opt/dgidb/data.sql.gz" | sha256sum --check
+
+FROM postgres:18-bookworm AS database-build
+
+ENV PGDATA=/var/lib/dgidb/postgres
+
+COPY --from=data-download /opt/dgidb/data.sql.gz /opt/dgidb/data.sql.gz
+COPY server/db/structure.sql /opt/dgidb/structure.sql
+COPY --chmod=755 docker/postgres/build-dgidb.sh /usr/local/bin/build-dgidb
+
+RUN build-dgidb && rm -rf /opt/dgidb /usr/local/bin/build-dgidb
+
+# Copying the filesystem into a fresh image retains the official PostgreSQL
+# runtime without inheriting its VOLUME declaration. PGDATA stays in the image.
+FROM scratch
+
+COPY --from=database-build / /
+
+ARG DGIDB_DATA_RELEASE=latest
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/18/bin \
+    LANG=en_US.utf8 \
+    PG_MAJOR=18 \
+    PGDATA=/var/lib/dgidb/postgres
+
+LABEL org.opencontainers.image.source="https://github.com/dgidb/dgidb-v5" \
+      org.opencontainers.image.description="PostgreSQL with an initialized read-only DGIdb database" \
+      org.dgidb.data.requested-release="${DGIDB_DATA_RELEASE}"
+
+EXPOSE 5432
+
+STOPSIGNAL SIGINT
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["postgres"]

--- a/docker/postgres/build-dgidb.sh
+++ b/docker/postgres/build-dgidb.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+install -d -m 0700 -o postgres -g postgres "$PGDATA"
+gosu postgres initdb \
+  --username=postgres \
+  --auth-local=trust \
+  --auth-host=reject
+
+stop_postgres() {
+  if [ -s "$PGDATA/postmaster.pid" ]; then
+    gosu postgres pg_ctl --pgdata "$PGDATA" --mode=fast --wait stop
+  fi
+}
+trap stop_postgres EXIT
+
+gosu postgres pg_ctl \
+  --pgdata "$PGDATA" \
+  --options="-c listen_addresses='' -c fsync=off -c full_page_writes=off -c synchronous_commit=off" \
+  --wait start
+
+gosu postgres createuser \
+  --no-createdb \
+  --no-createrole \
+  --no-superuser \
+  --no-replication \
+  dgidb
+gosu postgres createdb --owner=postgres dgidb
+
+gosu postgres psql \
+  --set=ON_ERROR_STOP=1 \
+  --dbname=dgidb \
+  --file=/opt/dgidb/structure.sql
+
+gzip --decompress --stdout /opt/dgidb/data.sql.gz | \
+  gosu postgres psql \
+    --set=ON_ERROR_STOP=1 \
+    --dbname=dgidb
+
+gosu postgres psql --set=ON_ERROR_STOP=1 --dbname=dgidb <<-'SQL'
+REVOKE ALL ON DATABASE dgidb FROM PUBLIC;
+GRANT CONNECT ON DATABASE dgidb TO dgidb;
+ALTER ROLE postgres NOLOGIN;
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO dgidb;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO dgidb;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO dgidb;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO dgidb;
+ALTER ROLE dgidb SET default_transaction_read_only = on;
+ALTER DATABASE dgidb SET default_transaction_read_only = on;
+VACUUM (FREEZE, ANALYZE);
+SQL
+
+stop_postgres
+trap - EXIT
+
+cat > "$PGDATA/pg_hba.conf" <<-'HBA'
+local dgidb dgidb trust
+local all all reject
+host dgidb dgidb 0.0.0.0/0 trust
+host dgidb dgidb ::0/0 trust
+host all all 0.0.0.0/0 reject
+host all all ::0/0 reject
+HBA
+
+cat >> "$PGDATA/postgresql.conf" <<-'CONF'
+
+# DGIdb is immutable at runtime.
+listen_addresses = '*'
+autovacuum = off
+CONF
+
+chown postgres:postgres "$PGDATA/pg_hba.conf" "$PGDATA/postgresql.conf"
+chmod 0600 "$PGDATA/pg_hba.conf" "$PGDATA/postgresql.conf"

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     erubi (1.13.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fiber-storage (1.0.1)
@@ -187,11 +188,14 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
+    pg (1.6.3-aarch64-linux)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pp (0.6.3)
@@ -289,6 +293,7 @@ GEM
       graphql (> 1.8)
       search_object (~> 1.2.5)
     securerandom (0.4.1)
+    sqlite3 (2.9.3-aarch64-linux-gnu)
     sqlite3 (2.9.3-arm64-darwin)
     sqlite3 (2.9.3-x86_64-linux-gnu)
     sshkit (1.25.0)
@@ -318,6 +323,7 @@ GEM
     zlib (3.2.3)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   arm64-darwin-25
   x86_64-linux

--- a/server/app/controllers/spa_controller.rb
+++ b/server/app/controllers/spa_controller.rb
@@ -1,0 +1,6 @@
+class SpaController < ApplicationController
+  def index
+    response.headers['Cache-Control'] = 'no-cache'
+    render html: File.read(Rails.root.join('public', 'index.html')).html_safe
+  end
+end

--- a/server/config/environments/production.rb
+++ b/server/config/environments/production.rb
@@ -19,16 +19,18 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Container images use Thruster for static files; the existing NGINX deploy keeps its defaults.
+  if ENV['DGIDB_CONTAINER'].present?
+    config.public_file_server.index_name = nil
+    config.public_file_server.headers = { 'cache-control' => 'public, max-age=3600' }
+    config.action_dispatch.x_sendfile_header = 'X-Sendfile'
+    config.active_storage.variant_processor = :disabled
+  end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -5,4 +5,13 @@ Rails.application.routes.draw do
   get '/api/counts', to: 'counts#index'
 
   mount GraphiQL::Rails::Engine, at: '/api/graphiql', graphql_path: '/api/graphql'
+
+  if ENV['DGIDB_CONTAINER'].present?
+    get '/up', to: 'rails/health#show', as: :rails_health_check
+    root 'spa#index'
+    get '*path', to: 'spa#index', constraints: lambda { |request|
+      request.get? && request.format.html? &&
+        !request.path.start_with?('/api/', '/rails/')
+    }
+  end
 end


### PR DESCRIPTION
This PR adds dockerfiles and supporting configuration/scripts to build the containers. There are two containers: one contains the application itself and the other contains postgres and the data dump baked into it already. There is a docker compose config that should allow a user to spin up a local instance with a single command. There are some minor changes to the server to accomodate this since we are not using docker in production and the server/assets sit behind a reverse proxy there.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>